### PR TITLE
feat: enrich /healthz with timestamp & uptime, add openrouter_configured to LlmSummary

### DIFF
--- a/server/src/domain/meta.rs
+++ b/server/src/domain/meta.rs
@@ -5,6 +5,10 @@ use crate::config::LlmProvider;
 #[derive(Serialize)]
 pub struct HealthResponse {
     pub status: &'static str,
+    /// Unix timestamp (seconds) when this response was generated.
+    pub timestamp: u64,
+    /// How long the server has been running, in seconds.
+    pub uptime_secs: u64,
 }
 
 #[derive(Serialize)]
@@ -25,4 +29,5 @@ pub struct LlmSummary {
     pub model: Option<String>,
     pub openai_configured: bool,
     pub anthropic_configured: bool,
+    pub openrouter_configured: bool,
 }

--- a/server/src/routes/health.rs
+++ b/server/src/routes/health.rs
@@ -1,11 +1,37 @@
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use axum::{Json, Router, routing::get};
 
 use crate::domain::meta::HealthResponse;
 
+static START_TIME: OnceLock<u64> = OnceLock::new();
+
+fn start_time() -> u64 {
+    *START_TIME.get_or_init(|| {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    })
+}
+
 pub fn router() -> Router<crate::app::state::AppState> {
+    // Touch start_time on router init so uptime is measured from server start,
+    // not the first health check.
+    start_time();
     Router::new().route("/healthz", get(health))
 }
 
 async fn health() -> Json<HealthResponse> {
-    Json(HealthResponse { status: "ok" })
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let started_at = start_time();
+    Json(HealthResponse {
+        status: "ok",
+        timestamp: now,
+        uptime_secs: now.saturating_sub(started_at),
+    })
 }

--- a/server/src/routes/meta.rs
+++ b/server/src/routes/meta.rs
@@ -28,6 +28,7 @@ async fn server_meta(State(state): State<AppState>) -> Json<ServerMetaResponse> 
             model: cfg.llm.model.clone(),
             openai_configured: !cfg.llm.tokens.open_ai.trim().is_empty(),
             anthropic_configured: !cfg.llm.tokens.anthropic.trim().is_empty(),
+            openrouter_configured: !cfg.llm.tokens.open_router.trim().is_empty(),
         },
     })
 }


### PR DESCRIPTION
## What

Two small improvements to the server's diagnostic endpoints.

### `/healthz` — richer health response

Before:
```json
{ "status": "ok" }
```

After:
```json
{
  "status": "ok",
  "timestamp": 1742076123,
  "uptime_secs": 3847
}
```

`timestamp` lets monitoring tools detect stale/cached responses. `uptime_secs` gives a quick read on stability without digging through logs — useful when debugging restarts or checking if a deploy landed.

Uptime is measured from router init (server start), not the first health check, so it's accurate from the very first request.

### `/api/meta` — `openrouter_configured` in `LlmSummary`

`LlmSummary` already exposes `openai_configured` and `anthropic_configured`, but OpenRouter is fully supported in config yet invisible in the meta endpoint. This adds `openrouter_configured` for consistency.

## Changes

- `server/src/domain/meta.rs` — added `timestamp`, `uptime_secs` to `HealthResponse`; added `openrouter_configured` to `LlmSummary`
- `server/src/routes/health.rs` — added `START_TIME` static, compute uptime on each request
- `server/src/routes/meta.rs` — populate `openrouter_configured` field