### PR TITLE
feat(client): auto-resize textarea to fit content

### DIFF
--- a/client/src/lib/components/chat/ChatInput.svelte
+++ b/client/src/lib/components/chat/ChatInput.svelte
@@ -42,6 +42,16 @@
 		}
 	});
 
+	// Auto-resize textarea to fit content, up to max-height
+	$effect(() => {
+		// Track value so this effect re-runs on every keystroke
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+		value;
+		if (!textareaEl) return;
+		textareaEl.style.height = "auto";
+		textareaEl.style.height = `${textareaEl.scrollHeight}px`;
+	});
+
 	function handleSubmit() {
 		const trimmed = value.trim();
 		if ((!trimmed && attachments.length === 0) || disabled) return;
@@ -362,7 +372,8 @@
 		flex: 1;
 		min-width: 0;
 		min-height: 44px;
-		max-height: 120px;
+		max-height: 200px;
+		overflow-y: auto;
 		resize: none;
 		padding: 0.75rem 1rem;
 		font-family: var(--font-body);


### PR DESCRIPTION
## Problem

The chat input textarea was fixed at `rows=1` with a CSS `max-height: 120px`. When typing a long message, text would scroll inside the fixed-height box rather than the element growing — making it hard to review what you had written before sending.

## Fix

Added a Svelte `$effect` that watches `value` and sets `textarea.style.height` to its `scrollHeight` on every change:

```ts
$effect(() => {
  value; // track for reactivity
  if (!textareaEl) return;
  textareaEl.style.height = "auto";
  textareaEl.style.height = `${textareaEl.scrollHeight}px`;
});
```

The reset to `"auto"` before measuring ensures the height shrinks correctly when text is deleted or the message is sent.

Also:
- `max-height` bumped from `120px` → `200px` for more breathing room
- Added `overflow-y: auto` so scrolling kicks in only at the cap, not before

After sending, `value` resets to `""` — the effect re-runs automatically and collapses the textarea back to one row.