### PR TITLE
feat: haptic feedback via Vibration API

### DIFF
--- a/client/src/lib/components/chat/ChatInput.svelte
+++ b/client/src/lib/components/chat/ChatInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { play } from "$lib/sounds.js";
+	import { hapticLight, hapticMedium } from "$lib/haptics.js";
 	import UsageBar from "$lib/components/layout/UsageBar.svelte";
 
 	let {
@@ -56,6 +57,7 @@
 		const trimmed = value.trim();
 		if ((!trimmed && attachments.length === 0) || disabled) return;
 		play("message_send");
+		hapticLight();
 		onSend(trimmed, attachments.length > 0 ? [...attachments] : undefined);
 		value = "";
 		attachments = [];
@@ -76,6 +78,7 @@
 		const input = e.target as HTMLInputElement;
 		if (input.files && input.files.length > 0) {
 			play("attachment_added");
+			hapticMedium();
 			attachments = [...attachments, ...Array.from(input.files)];
 		}
 		input.value = "";
@@ -126,6 +129,7 @@
 		const files = e.dataTransfer?.files;
 		if (files && files.length > 0) {
 			play("attachment_added");
+			hapticMedium();
 			attachments = [...attachments, ...Array.from(files)];
 		}
 	}

--- a/client/src/lib/components/chat/ChatView.svelte
+++ b/client/src/lib/components/chat/ChatView.svelte
@@ -13,6 +13,7 @@
 	import ExcalidrawViewer from "$lib/components/ExcalidrawViewer.svelte";
 	import McpAppViewer from "./McpAppViewer.svelte";
 	import { play, playImmediate, preload } from "$lib/sounds.js";
+	import { hapticMedium, hapticDouble, hapticError } from "$lib/haptics.js";
 	import { getToasts } from "$lib/stores/toast.svelte.js";
 	import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 	import TerminalSquare from "@lucide/svelte/icons/terminal-square";
@@ -355,12 +356,13 @@
 					}
 					scrollToBottom();
 				} else {
-					if (msg.role === "assistant") play("message_receive");
+					if (msg.role === "assistant") { play("message_receive"); hapticMedium(); }
 					addMessage(msg);
 					refreshChatList();
 				}
 			} else if (event.type === "mood_updated") {
 				play("mood_shift");
+				hapticDouble();
 				mood = event.mood;
 				localStorage.setItem("mood:" + slug, event.mood);
 				// Activity is added via ChatMessageCreated "[system] mood → ..."
@@ -386,6 +388,7 @@
 					pushActivity("tool", `dropped: ${event.drop.title}`);
 				}
 				play("drop_received");
+				hapticDouble();
 			} else if (event.type === "tool_output_chunk") {
 				// Append chunk to live output activity, or create one
 				const liveIdx = stream.findLastIndex(
@@ -464,6 +467,7 @@
 			for (const msg of res.messages) addMessage(msg);
 		} catch (e) {
 			play("error");
+			hapticError();
 			sending = false;
 			const msg = e instanceof Error ? e.message : "failed to send";
 			if (msg.includes("rate limit")) {

--- a/client/src/lib/components/drops/DropsView.svelte
+++ b/client/src/lib/components/drops/DropsView.svelte
@@ -4,6 +4,7 @@
 	import { getWebSocket } from "$lib/stores/websocket.svelte.js";
 	import { getToasts } from "$lib/stores/toast.svelte.js";
 	import { play } from "$lib/sounds.js";
+	import { hapticDouble } from "$lib/haptics.js";
 	import DropCard from "./DropCard.svelte";
 
 	const toast = getToasts();
@@ -34,6 +35,7 @@
 			if (event.type === "drop_created" && event.instance_slug === slug) {
 				drops = [event.drop, ...drops];
 				play("drop_received");
+				hapticDouble();
 			}
 		});
 

--- a/client/src/lib/components/onboarding/InstanceOnboarding.svelte
+++ b/client/src/lib/components/onboarding/InstanceOnboarding.svelte
@@ -12,6 +12,7 @@
 	import { getInstances } from "$lib/stores/instances.svelte.js";
 	import { getToasts } from "$lib/stores/toast.svelte.js";
 	import { play, playImmediate, preload } from "$lib/sounds.js";
+	import { hapticReveal } from "$lib/haptics.js";
 
 	const toast = getToasts();
 	import AsciiRenderer from "$lib/components/chat/AsciiRenderer.svelte";
@@ -125,6 +126,7 @@
 		preload("intro_reveal", "typewriter");
 		await pause(600);
 		play("intro_reveal");
+		hapticReveal();
 		revealed = true;
 		await pause(1800);
 		stage = "intro";

--- a/client/src/lib/haptics.ts
+++ b/client/src/lib/haptics.ts
@@ -1,0 +1,39 @@
+/**
+ * Haptic feedback via Vibration API.
+ * Silently no-ops on unsupported devices (desktop, iOS Safari).
+ */
+
+function vibrate(pattern: number | number[]) {
+	if (typeof navigator === "undefined") return;
+	if (!("vibrate" in navigator)) return;
+	try {
+		navigator.vibrate(pattern);
+	} catch {
+		// ignore
+	}
+}
+
+/** Short tap — sending a message, pressing a button */
+export function hapticLight() {
+	vibrate(10);
+}
+
+/** Medium — receiving a message, attachment added */
+export function hapticMedium() {
+	vibrate(20);
+}
+
+/** Double tap — drop received, mood shift */
+export function hapticDouble() {
+	vibrate([12, 60, 12]);
+}
+
+/** Error — something went wrong */
+export function hapticError() {
+	vibrate([30, 50, 30]);
+}
+
+/** Soft reveal — onboarding intro */
+export function hapticReveal() {
+	vibrate([8, 40, 8, 40, 8]);
+}


### PR DESCRIPTION
adds `haptics.ts` — thin wrapper around `navigator.vibrate` with typed patterns. silently no-ops on unsupported devices (desktop, iOS Safari).

**wired to:**
- `message_send` → light tap (10ms)
- `message_receive` → medium (20ms)
- `attachment_added` → medium (20ms)
- `mood_shift` → double tap (12·60·12ms)
- `drop_received` → double tap
- `error` → error pattern (30·50·30ms)
- `intro_reveal` → soft reveal sequence