### PR TITLE
Fix file download + pass GITHUB_TOKEN to run_command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/server/src/routes/uploads.rs
+++ b/server/src/routes/uploads.rs
@@ -141,12 +141,22 @@ async fn serve_file_inner(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
+    let content_disposition = format!(
+        "attachment; filename=\"{}\"",
+        meta.original_name.replace('"', "_")
+    );
+
     Response::builder()
         .header(
             header::CONTENT_TYPE,
             HeaderValue::from_str(&meta.mime_type).unwrap_or_else(|_| {
                 HeaderValue::from_static("application/octet-stream")
             }),
+        )
+        .header(
+            header::CONTENT_DISPOSITION,
+            HeaderValue::from_str(&content_disposition)
+                .unwrap_or_else(|_| HeaderValue::from_static("attachment")),
         )
         .header(
             header::CACHE_CONTROL,

--- a/server/src/services/chat.rs
+++ b/server/src/services/chat.rs
@@ -362,6 +362,12 @@ pub async fn run_single_turn(
         .as_ref()
         .map(|c| c.llm.tokens.open_router.clone())
         .unwrap_or_default();
+    let github_token = chat_config
+        .as_ref()
+        .and_then(|c| {
+            let t = c.github.token.clone();
+            if t.is_empty() { None } else { Some(t) }
+        });
     let (all_tools, sent_files) = tools::build_tools(
         workspace_dir, &instance_slug, &chat_id, brave_api_key,
         config_path, events.clone(), llm,
@@ -373,6 +379,7 @@ pub async fn run_single_turn(
         Some(mcp_snapshot.clone()),
         mcp_tools,
         &openrouter_key,
+        github_token,
     );
     tools::cache_tool_defs(&all_tools).await;
 

--- a/server/src/services/tools/mod.rs
+++ b/server/src/services/tools/mod.rs
@@ -445,6 +445,7 @@ pub fn build_tools(
     mcp_snapshot: Option<crate::services::mcp::McpAppSnapshot>,
     mcp_tools: Vec<Box<dyn ToolDyn>>,
     openrouter_key: &str,
+    github_token: Option<String>,
 ) -> (Vec<Box<dyn ToolDyn>>, SentFiles) {
     let snap = mcp_snapshot;
     let wrap = |tool: Box<dyn ToolDyn>| -> Box<dyn ToolDyn> {
@@ -473,7 +474,7 @@ pub fn build_tools(
         wrap(Box::new(MemorySearchTool::new(workspace_dir, instance_slug))),
         // Mood is managed by background sentiment extraction + heartbeat, not tools.
         wrap(Box::new(EditSoulTool::new(workspace_dir, instance_slug))),
-        wrap(Box::new(RunCommandTool::new(workspace_dir, instance_slug, chat_id, events.clone()))),
+        wrap(Box::new(RunCommandTool::new(workspace_dir, instance_slug, chat_id, events.clone(), github_token))),
         wrap(Box::new(ClearContextTool::new(workspace_dir, instance_slug))),
     ];
 

--- a/server/src/services/tools/system.rs
+++ b/server/src/services/tools/system.rs
@@ -89,24 +89,21 @@ impl Tool for RunCommandTool {
         let timeout = args.timeout_secs.unwrap_or(30).min(300);
         let use_pty = args.pty.unwrap_or(true);
 
-        // Prepend GitHub token exports so gh CLI works without extra setup
-        let command = if let Some(ref token) = self.github_token {
-            if !token.is_empty() {
-                let escaped = token.replace('\'', "'\\''");
-                format!("export GITHUB_TOKEN='{}' GH_TOKEN='{}'; {}", escaped, escaped, command)
-            } else {
-                command
-            }
-        } else {
-            command
-        };
-
         log::info!(
             "[run_command] executing: {} (cwd: {}, pty: {})",
             command,
             work_dir.display(),
             use_pty
         );
+
+        // Prepend GitHub token exports so gh CLI works without extra setup
+        // Done AFTER logging to avoid leaking the token to logs
+        let command = if let Some(ref token) = self.github_token {
+            let escaped = token.replace('\'', "'\\''");
+            format!("export GITHUB_TOKEN='{}' GH_TOKEN='{}'; {}", escaped, escaped, command)
+        } else {
+            command
+        };
 
         if use_pty {
             let cmd = command.clone();

--- a/server/src/services/tools/system.rs
+++ b/server/src/services/tools/system.rs
@@ -24,6 +24,7 @@ pub struct RunCommandTool {
     events: broadcast::Sender<ServerEvent>,
     instance_slug: String,
     chat_id: String,
+    github_token: Option<String>,
 }
 
 impl RunCommandTool {
@@ -32,12 +33,14 @@ impl RunCommandTool {
         instance_slug: &str,
         chat_id: &str,
         events: broadcast::Sender<ServerEvent>,
+        github_token: Option<String>,
     ) -> Self {
         Self {
             instance_dir: workspace_dir.join("instances").join(instance_slug),
             events,
             instance_slug: instance_slug.to_string(),
             chat_id: chat_id.to_string(),
+            github_token,
         }
     }
 }
@@ -85,6 +88,18 @@ impl Tool for RunCommandTool {
 
         let timeout = args.timeout_secs.unwrap_or(30).min(300);
         let use_pty = args.pty.unwrap_or(true);
+
+        // Prepend GitHub token exports so gh CLI works without extra setup
+        let command = if let Some(ref token) = self.github_token {
+            if !token.is_empty() {
+                let escaped = token.replace('\'', "'\\''");
+                format!("export GITHUB_TOKEN='{}' GH_TOKEN='{}'; {}", escaped, escaped, command)
+            } else {
+                command
+            }
+        } else {
+            command
+        };
 
         log::info!(
             "[run_command] executing: {} (cwd: {}, pty: {})",


### PR DESCRIPTION
Two fixes:
1. Add `Content-Disposition: attachment` header so browsers download files instead of displaying them (JSON, text, etc)
2. Pass `GITHUB_TOKEN` and `GH_TOKEN` from config to `run_command` env so gh CLI works without manual export

Fixes send_file bug where JSON files were displayed in browser instead of downloaded.