### PR TITLE
feat: per-instance config (instance.toml) for github token

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -61,6 +61,51 @@ pub struct EmailConfig {
 fn default_smtp_port() -> u16 { 587 }
 fn default_imap_port() -> u16 { 993 }
 
+/// Per-instance configuration stored at `instances/{slug}/instance.toml`.
+/// Holds settings that are specific to one user/instance, such as GitHub token.
+/// Takes precedence over global `config.toml` for the same fields.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct InstanceConfig {
+    #[serde(default)]
+    pub github: GithubConfig,
+}
+
+impl InstanceConfig {
+    /// Load per-instance config from `instances/{slug}/instance.toml`.
+    /// Returns default (empty) config if the file doesn't exist.
+    pub fn load(workspace_dir: &Path, instance_slug: &str) -> Self {
+        let path = workspace_dir
+            .join("instances")
+            .join(instance_slug)
+            .join("instance.toml");
+        let raw = match fs::read_to_string(&path) {
+            Ok(r) => r,
+            Err(_) => return Self::default(),
+        };
+        toml::from_str::<InstanceConfig>(&raw).unwrap_or_default()
+    }
+
+    /// Save per-instance config to `instances/{slug}/instance.toml`.
+    pub fn save(&self, workspace_dir: &Path, instance_slug: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let dir = workspace_dir.join("instances").join(instance_slug);
+        fs::create_dir_all(&dir)?;
+        let raw = toml::to_string_pretty(self)?;
+        fs::write(dir.join("instance.toml"), raw)?;
+        Ok(())
+    }
+
+    /// Return the effective GitHub token: instance-level if set, otherwise fall back to global.
+    pub fn effective_github_token<'a>(&'a self, global: &'a Config) -> Option<&'a str> {
+        if !self.github.token.is_empty() {
+            return Some(&self.github.token);
+        }
+        if !global.github.token.is_empty() {
+            return Some(&global.github.token);
+        }
+        None
+    }
+}
+
 /// Wrapper for `instances/{slug}/email.toml` — supports multiple accounts.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct EmailAccounts {

--- a/server/src/services/chat.rs
+++ b/server/src/services/chat.rs
@@ -158,6 +158,7 @@ pub async fn run_single_turn(
     let google_connected = !google_accounts.is_empty();
 
     let email_accounts = crate::config::EmailAccounts::load(workspace_dir, &instance_slug);
+    let instance_cfg = crate::config::InstanceConfig::load(workspace_dir, &instance_slug);
     let email_configured = !email_accounts.is_empty();
     let has_any_email = google_connected || email_configured;
     let google_hint = if google_connected && email_configured {
@@ -233,8 +234,8 @@ pub async fn run_single_turn(
 
     // GitHub integration hint
     {
-        let gh_configured = chat_config.as_ref()
-            .is_some_and(|c| !c.github.token.is_empty());
+        let global_gh = chat_config.as_ref().is_some_and(|c| !c.github.token.is_empty());
+        let gh_configured = global_gh || !instance_cfg.github.token.is_empty();
         if gh_configured {
             system_prompt.push_str(
                 "\n\n## github\n\
@@ -362,6 +363,13 @@ pub async fn run_single_turn(
         .as_ref()
         .map(|c| c.llm.tokens.open_router.clone())
         .unwrap_or_default();
+    // Prefer instance-level github token; fall back to global config
+    let github_token = {
+        let global_token = chat_config.as_ref().map(|c| c.github.token.clone()).unwrap_or_default();
+        let instance_token = instance_cfg.github.token.clone();
+        let t = if !instance_token.is_empty() { instance_token } else { global_token };
+        if t.is_empty() { None } else { Some(t) }
+    };
     let (all_tools, sent_files) = tools::build_tools(
         workspace_dir, &instance_slug, &chat_id, brave_api_key,
         config_path, events.clone(), llm,
@@ -373,6 +381,7 @@ pub async fn run_single_turn(
         Some(mcp_snapshot.clone()),
         mcp_tools,
         &openrouter_key,
+        github_token,
     );
     tools::cache_tool_defs(&all_tools).await;
 

--- a/server/src/services/tools/mod.rs
+++ b/server/src/services/tools/mod.rs
@@ -445,6 +445,7 @@ pub fn build_tools(
     mcp_snapshot: Option<crate::services::mcp::McpAppSnapshot>,
     mcp_tools: Vec<Box<dyn ToolDyn>>,
     openrouter_key: &str,
+    github_token: Option<String>,
 ) -> (Vec<Box<dyn ToolDyn>>, SentFiles) {
     let snap = mcp_snapshot;
     let wrap = |tool: Box<dyn ToolDyn>| -> Box<dyn ToolDyn> {
@@ -473,7 +474,7 @@ pub fn build_tools(
         wrap(Box::new(MemorySearchTool::new(workspace_dir, instance_slug))),
         // Mood is managed by background sentiment extraction + heartbeat, not tools.
         wrap(Box::new(EditSoulTool::new(workspace_dir, instance_slug))),
-        wrap(Box::new(RunCommandTool::new(workspace_dir, instance_slug, chat_id, events.clone()))),
+        wrap(Box::new(RunCommandTool::new(workspace_dir, instance_slug, chat_id, events.clone(), github_token))),
         wrap(Box::new(ClearContextTool::new(workspace_dir, instance_slug))),
     ];
 

--- a/server/src/services/tools/system.rs
+++ b/server/src/services/tools/system.rs
@@ -24,6 +24,7 @@ pub struct RunCommandTool {
     events: broadcast::Sender<ServerEvent>,
     instance_slug: String,
     chat_id: String,
+    github_token: Option<String>,
 }
 
 impl RunCommandTool {
@@ -32,12 +33,14 @@ impl RunCommandTool {
         instance_slug: &str,
         chat_id: &str,
         events: broadcast::Sender<ServerEvent>,
+        github_token: Option<String>,
     ) -> Self {
         Self {
             instance_dir: workspace_dir.join("instances").join(instance_slug),
             events,
             instance_slug: instance_slug.to_string(),
             chat_id: chat_id.to_string(),
+            github_token,
         }
     }
 }
@@ -85,6 +88,14 @@ impl Tool for RunCommandTool {
 
         let timeout = args.timeout_secs.unwrap_or(30).min(300);
         let use_pty = args.pty.unwrap_or(true);
+
+        // Prepend GITHUB_TOKEN export so gh CLI works without manual export
+        let command = if let Some(ref token) = self.github_token {
+            let escaped = token.replace('\'', "\\'");
+            format!("export GITHUB_TOKEN='{escaped}' GH_TOKEN='{escaped}'; {command}")
+        } else {
+            command
+        };
 
         log::info!(
             "[run_command] executing: {} (cwd: {}, pty: {})",
@@ -855,10 +866,13 @@ impl Tool for GetSettingsTool {
                 }
 
                 // GitHub
-                if config.github.token.is_empty() {
-                    lines.push("github: not connected".into());
-                } else {
+                // GitHub — check instance config first, then fall back to global
+                let instance_cfg = crate::config::InstanceConfig::load(&self.workspace_dir, &self.instance_slug);
+                let github_token_set = !instance_cfg.github.token.is_empty() || !config.github.token.is_empty();
+                if github_token_set {
                     lines.push("github: token configured".into());
+                } else {
+                    lines.push("github: not connected".into());
                 }
 
                 // MCP servers
@@ -1129,7 +1143,11 @@ impl Tool for UpdateConfigTool {
 
         if let Some(token) = &args.github_token {
             let token = token.trim().to_string();
-            config.github.token = token.clone();
+            // Write github token to per-instance config, not global
+            let mut instance_cfg = crate::config::InstanceConfig::load(&self.workspace_dir, &self.instance_slug);
+            instance_cfg.github.token = token.clone();
+            instance_cfg.save(&self.workspace_dir, &self.instance_slug)
+                .map_err(|e| ToolExecError(format!("failed to save instance config: {e}")))?;
             changes.push(if token.is_empty() { "github token removed".into() } else { "github token updated".into() });
         }
 
@@ -1174,7 +1192,6 @@ impl Tool for UpdateConfigTool {
         if args.provider.is_some() || args.model.is_some() || args.openai_key.is_some()
             || args.anthropic_key.is_some() || args.brave_search_key.is_some()
             || args.add_mcp_server.is_some() || args.remove_mcp_server.is_some()
-            || args.github_token.is_some()
         {
             let output = toml::to_string_pretty(&config)
                 .map_err(|e| ToolExecError(format!("failed to serialize config: {e}")))?;
@@ -1725,7 +1742,8 @@ fn is_allowed_secret_target(target: &str) -> bool {
 
 /// Write a secret value to the appropriate config file based on the dotted target path.
 fn write_secret_to_config(
-    _instance_dir: &Path,
+    workspace_dir: &Path,
+    instance_slug: &str,
     config_path: &Path,
     target: &str,
     value: &str,
@@ -1750,15 +1768,10 @@ fn write_secret_to_config(
                 .map_err(|e| ToolExecError(format!("failed to write config: {e}")))?;
         }
         ["github", "token"] => {
-            let raw = fs::read_to_string(config_path)
-                .map_err(|e| ToolExecError(format!("failed to read config: {e}")))?;
-            let mut config: crate::config::Config = toml::from_str(&raw)
-                .map_err(|e| ToolExecError(format!("failed to parse config: {e}")))?;
-            config.github.token = value.to_string();
-            let output = toml::to_string_pretty(&config)
-                .map_err(|e| ToolExecError(format!("failed to serialize config: {e}")))?;
-            fs::write(config_path, &output)
-                .map_err(|e| ToolExecError(format!("failed to write config: {e}")))?;
+            let mut instance_cfg = crate::config::InstanceConfig::load(workspace_dir, instance_slug);
+            instance_cfg.github.token = value.to_string();
+            instance_cfg.save(workspace_dir, instance_slug)
+                .map_err(|e| ToolExecError(format!("failed to save instance config: {e}")))?;
         }
         _ => return Err(ToolExecError(format!("unsupported target path: {target}"))),
     }
@@ -1767,6 +1780,7 @@ fn write_secret_to_config(
 
 pub struct RequestSecretTool {
     instance_slug: String,
+    workspace_dir: PathBuf,
     instance_dir: PathBuf,
     config_path: PathBuf,
     events: broadcast::Sender<ServerEvent>,
@@ -1783,6 +1797,7 @@ impl RequestSecretTool {
     ) -> Self {
         Self {
             instance_slug: instance_slug.to_string(),
+            workspace_dir: workspace_dir.to_path_buf(),
             instance_dir: workspace_dir.join("instances").join(instance_slug),
             config_path: config_path.to_path_buf(),
             events,
@@ -1867,7 +1882,7 @@ impl Tool for RequestSecretTool {
             .map_err(|_| ToolExecError("secret request was cancelled".into()))?;
 
         // Write to config
-        write_secret_to_config(&self.instance_dir, &self.config_path, &target, &value)?;
+        write_secret_to_config(&self.workspace_dir, &self.instance_slug, &self.config_path, &target, &value)?;
 
         log::info!("[request_secret] secret saved to {target}");
         Ok(format!("secret saved to {target}"))


### PR DESCRIPTION
## What

Moves github token from global `config.toml` to per-instance `instances/{slug}/instance.toml`, following the same pattern as `email.toml`.

## Why

Currently all users on a bolly instance share the same github token from the global config. This doesn't make sense — github tokens should be personal, not server-wide. An instance should own its own credentials.

## How

### New `InstanceConfig` struct (`config.rs`)
```toml
# instances/{slug}/instance.toml
[github]
token = "ghp_..."
```
- `InstanceConfig::load(workspace_dir, slug)` — reads from instance.toml, returns default if absent
- `InstanceConfig::save(workspace_dir, slug)` — writes instance.toml
- `InstanceConfig::effective_github_token(&self, global)` — instance token takes precedence over global

### Token lookup (`chat.rs`)
- Loads instance config alongside email accounts
- Prefers instance-level token, falls back to global config token
- System prompt hint ("github token configured") checks both

### Token write (`tools/system.rs`)
- `update_config` tool: writes github_token to `instance.toml` instead of `config.toml`
- `request_secret` tool: `github.token` target writes to `instance.toml`
- `get_settings` tool: checks both instance and global configs

### RunCommandTool
- Now accepts `github_token: Option<String>`
- Prepends `export GITHUB_TOKEN='...' GH_TOKEN='...'` to every command when token is set
- This means `gh` CLI works out of the box without manual export

## Migration
No migration needed — if `instance.toml` doesn't exist, falls back to global config transparently. Existing deployments with a global token continue to work.