### PR TITLE
perf: strip memory catalog from conversation history

### DIFF
--- a/server/src/services/chat.rs
+++ b/server/src/services/chat.rs
@@ -307,6 +307,23 @@ pub async fn run_single_turn(
     let prompt_msg = llm::build_multimodal_prompt(&content_with_time, workspace_dir, &instance_slug, pdf_strategy);
 
     let mut history_msgs = if let Some(mut h) = loaded_history {
+        // Strip [context] blocks from historical user messages.
+        // The memory catalog is appended to every user message before sending to the LLM,
+        // but it also gets saved into rig_history.json — meaning each turn re-sends all
+        // previous copies of the catalog. With 280+ files that's ~20k chars per message.
+        // We only need the catalog in the *current* message, not in history.
+        for msg in h.iter_mut() {
+            if let llm::Message::User { content } = msg {
+                for block in content.iter_mut() {
+                    if let llm::ContentBlock::Text { text } = block {
+                        if let Some(ctx_pos) = text.find("\n\n[context]\n") {
+                            text.truncate(ctx_pos);
+                        }
+                    }
+                }
+            }
+        }
+
         // Check if history already has a compaction block — if so, the context
         // was intentionally reset. Don't patch in old messages.json entries or
         // we'll refill the context and trigger compaction in a loop.


### PR DESCRIPTION
## Problem

The `[context]` block (full memory catalog) is appended to every user message before sending to the LLM. This block also gets saved into `rig_history.json`, so every subsequent request re-sends **all previous copies** of the catalog.

With 280+ memory files (~20k chars each), a 10-message chat sends ~200k unnecessary chars on every single turn.

Visible in context breakdown dashboard: 55.9k tokens for 33 messages — ~1700 tokens/msg average, most of it catalog duplication.

## Fix

When loading `rig_history` before an API call, strip `[context]` blocks from historical user messages. Truncates at `\n\n[context]\n` — preserves timestamp and message text, removes the catalog tail.

The current request always gets a fresh catalog — history entries don't need it.

## Impact

- History token count drops proportionally to conversation length
- For active chats (30+ messages): saves ~500k+ chars per request
- No behavioral change — catalog is always up to date in the new message
- Existing `rig_history.json` files benefit immediately on next request