### PR TITLE
perf: static memory catalog snapshot in system prompt

### DIFF
--- a/server/src/services/chat.rs
+++ b/server/src/services/chat.rs
@@ -128,8 +128,9 @@ pub async fn run_single_turn(
         .map(|m| m.content.as_str())
         .unwrap_or("");
 
-    // Build memory prompt from library — appended to user prompt, not system
-    let memory_prompt = memory::build_memory_prompt(workspace_dir, &instance_slug);
+    // Load static memory catalog snapshot — built once at context clear / compaction,
+    // not scanned on every request.
+    let memory_prompt = memory::load_catalog_snapshot(workspace_dir, &instance_slug);
 
     let chat_config = crate::config::load_config().ok();
     let auth_token = std::env::var("BOLLY_AUTH_TOKEN")
@@ -282,8 +283,11 @@ pub async fn run_single_turn(
 
     // System prompt is fully static (soul, skills, style, integrations).
     // Mood and rhythm changes are recorded as messages in rig_history.
-    // Memory catalog is lightweight context injected with the user prompt.
-    let system_static = system_prompt;
+    // Memory catalog is a static snapshot — rebuilt only on context clear / compaction.
+    let mut system_static = system_prompt;
+    if !memory_prompt.is_empty() {
+        system_static.push_str(&format!("\n\n{memory_prompt}"));
+    }
 
     // Build Rig message history from rig_history.json (source of truth) or
     // fall back to converting messages.json.
@@ -300,10 +304,7 @@ pub async fn run_single_turn(
         .ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "no user message to process"))?;
     let instance_dir = workspace_dir.join("instances").join(&instance_slug);
     let now = crate::routes::instances::format_instance_now(&instance_dir);
-    let mut content_with_time = format!("[{now}]\n{}", last_user.content);
-    if !memory_prompt.is_empty() {
-        content_with_time.push_str(&format!("\n\n[context]\n{memory_prompt}"));
-    }
+    let content_with_time = format!("[{now}]\n{}", last_user.content);
     let prompt_msg = llm::build_multimodal_prompt(&content_with_time, workspace_dir, &instance_slug, pdf_strategy);
 
     let mut history_msgs = if let Some(mut h) = loaded_history {
@@ -542,6 +543,19 @@ pub async fn run_single_turn(
     if let Some(ref h) = tool_result.rig_history {
         let rig_path = rig_history_path(workspace_dir, &instance_slug, &chat_id);
         save_rig_history(&rig_path, h);
+
+        // If compaction fired, rebuild the memory catalog snapshot so the
+        // fresh system prompt gets an up-to-date catalog.
+        let had_compaction = h.iter().any(|msg| {
+            if let llm::Message::Assistant { content } = msg {
+                content.iter().any(|b| matches!(b, llm::ContentBlock::Compaction { .. }))
+            } else {
+                false
+            }
+        });
+        if had_compaction {
+            memory::rebuild_catalog_snapshot(workspace_dir, &instance_slug);
+        }
     }
 
     // Use real token count from API if available, fall back to estimate
@@ -578,6 +592,10 @@ pub fn load_messages(workspace_dir: &Path, instance_slug: &str, chat_id: &str) -
 pub fn clear_context(workspace_dir: &Path, instance_slug: &str, chat_id: &str) {
     let instance_slug = sanitize_slug(instance_slug);
     let chat_id = sanitize_slug(chat_id);
+
+    // Rebuild memory catalog snapshot — the static catalog in system prompt
+    // must be fresh after context is cleared.
+    memory::rebuild_catalog_snapshot(workspace_dir, &instance_slug);
 
     // No need to snapshot stats — daily_stats files are written incrementally
     // and never deleted by clear_context.

--- a/server/src/services/memory.rs
+++ b/server/src/services/memory.rs
@@ -65,9 +65,50 @@ fn scan_dir_recursive(base: &Path, current: &Path, entries: &mut Vec<MemoryEntry
     }
 }
 
+/// Path to the static memory catalog snapshot file for an instance.
+fn catalog_snapshot_path(workspace_dir: &Path, instance_slug: &str) -> std::path::PathBuf {
+    workspace_dir
+        .join("instances")
+        .join(instance_slug)
+        .join("memory_catalog.txt")
+}
+
+/// Rebuild and persist the memory catalog snapshot to disk.
+/// Call this after context clear or compaction — not on every request.
+pub fn rebuild_catalog_snapshot(workspace_dir: &Path, instance_slug: &str) {
+    let entries = scan_library(workspace_dir, instance_slug);
+    if entries.is_empty() {
+        return;
+    }
+
+    let mut prompt = format!(
+        "## memory\nyou have a personal memory library. use `recall` to read memories when relevant.\ncatalog ({} files):\n",
+        entries.len()
+    );
+    for entry in &entries {
+        prompt.push_str(&format!("- {} — {}\n", entry.path, entry.summary));
+    }
+    prompt.push_str("\nuse these memories naturally — `recall` what you need. don't announce that you remember — just know.");
+
+    let path = catalog_snapshot_path(workspace_dir, instance_slug);
+    if let Err(e) = std::fs::write(&path, &prompt) {
+        log::warn!("[memory] failed to write catalog snapshot: {e}");
+    } else {
+        log::info!("[memory] catalog snapshot rebuilt: {} files", entries.len());
+    }
+}
+
+/// Load the static memory catalog snapshot from disk.
+/// Returns empty string if no snapshot exists yet (first boot / pre-compaction).
+pub fn load_catalog_snapshot(workspace_dir: &Path, instance_slug: &str) -> String {
+    let path = catalog_snapshot_path(workspace_dir, instance_slug);
+    std::fs::read_to_string(&path).unwrap_or_default()
+}
+
 /// Build the memory prompt for the system prompt.
 /// For small libraries (< 6000 chars total), inline all file contents.
 /// For larger ones, show a catalog with summaries + inline the smallest files.
+/// NOTE: this scans disk on every call — use load_catalog_snapshot() for the static version.
 pub fn build_memory_prompt(workspace_dir: &Path, instance_slug: &str) -> String {
     let entries = scan_library(workspace_dir, instance_slug);
     if entries.is_empty() {


### PR DESCRIPTION
## What

Instead of scanning all memory files on every LLM request (~15-20k tokens overhead), build a static catalog snapshot once and load it from disk.

## Why

- `build_memory_prompt` was scanning 300+ files on every single request
- Every user has a different memory structure — no folder assumptions safe
- Catalog was being appended to user messages (and stripped from history), adding complexity

## How

- Added `rebuild_catalog_snapshot()` in `memory.rs` — writes catalog to `memory_catalog.txt`
- Added `load_catalog_snapshot()` — reads from disk, returns empty string if no snapshot yet
- Catalog moved to `system_static` (system prompt) instead of user message
- Snapshot rebuilt on: `clear_context()` and after server-side compaction fires
- Existing `build_memory_prompt` kept for token estimation stats only

## Impact

- ~15-20k tokens saved per request
- One disk read instead of full library scan
- Works for all users regardless of memory folder structure