### PR TITLE
Bolly v1.0: redesign spec, foundations plan, and TS server scaffold

### DIFF
--- a/docs/superpowers/plans/2026-04-22-foundations.md
+++ b/docs/superpowers/plans/2026-04-22-foundations.md
@@ -1,0 +1,2810 @@
+# Bolly v1 — Foundations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the isolated, unit-tested foundation modules of the new TS backend — filesystem helpers, budget ledger, triage rules parser, skills parser, and core types — so that Plan 2 (Mind runtime) can compose them into a running server.
+
+**Architecture:** A single standalone `server-ts/` pnpm package. Pure TypeScript modules with no runtime server, no Claude SDK calls, no HTTP. Everything testable in isolation with vitest. Modules grouped by responsibility (storage, budget, skills, triage, outreach-audit).
+
+**Tech Stack:** Node.js 22+, TypeScript 5.x, pnpm, vitest, zod (schema validation), gray-matter (frontmatter), smol-toml (TOML), ulid (ids), tinyglobby (fs glob).
+
+**Scope (what this plan ships):**
+- `server-ts/` scaffolded with build + test commands
+- `src/paths.ts` — filesystem path helpers
+- `src/fs-atomic.ts` — atomic file write utilities
+- `src/json-file.ts` and `src/toml-file.ts` — typed read/write helpers
+- `src/types.ts` — core type definitions (Event, Skill, BudgetState, etc.)
+- `src/budget/state.ts` — pure state calculator
+- `src/budget/ledger.ts` — daily ledger load/save/recordSpend
+- `src/budget/charge-and-call.ts` — LLM call wrapper with enforcement
+- `src/budget/throttle.ts` — per-minute rolling window throttle
+- `src/skills/parse.ts` — frontmatter + body parser
+- `src/skills/loader.ts` — directory scanner
+- `src/triage/rules.ts` — triage.md reader
+- `src/triage/prompt.ts` — Haiku prompt builder (returns string, no API call)
+- `src/outreach/audit.ts` — outreach.jsonl appender
+- `src/settings/reader.ts` — settings.toml parser with defaults
+
+**Out of scope (later plans):**
+- Claude Agent SDK integration (Plan 2)
+- HTTP/WebSocket server (Plan 2)
+- Event queue, triage execution, scheduled jobs (Plan 3)
+- Outreach delivery (Plan 4)
+- Cross-instance (Plan 5)
+
+**Filesystem paths used in tests:** tests use `tmp/` directories from `node:os.tmpdir()` via `fs.mkdtemp`, cleaned up in `afterEach`. No writes to real `$BOLLY_HOME`.
+
+**Commit convention:** One commit per task. Messages use `feat:`, `test:`, `chore:` prefixes. All commits include the trailer `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+```
+server-ts/
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+├── biome.json
+├── .gitignore
+└── src/
+    ├── index.ts                  re-exports public API
+    ├── types.ts                  core type definitions
+    ├── paths.ts                  filesystem path helpers
+    ├── fs-atomic.ts              write-tmp-then-rename
+    ├── json-file.ts              typed JSON read/write
+    ├── toml-file.ts              typed TOML read/write
+    ├── budget/
+    │   ├── state.ts              pure state calculator
+    │   ├── state.test.ts
+    │   ├── ledger.ts             daily ledger module
+    │   ├── ledger.test.ts
+    │   ├── charge-and-call.ts    LLM wrapper
+    │   ├── charge-and-call.test.ts
+    │   ├── throttle.ts           per-minute throttle
+    │   └── throttle.test.ts
+    ├── skills/
+    │   ├── parse.ts              frontmatter + body parser
+    │   ├── parse.test.ts
+    │   ├── loader.ts             dir scanner
+    │   └── loader.test.ts
+    ├── triage/
+    │   ├── rules.ts              triage.md reader
+    │   ├── rules.test.ts
+    │   ├── prompt.ts             prompt string builder
+    │   └── prompt.test.ts
+    ├── outreach/
+    │   ├── audit.ts              jsonl appender
+    │   └── audit.test.ts
+    └── settings/
+        ├── reader.ts             settings.toml parser
+        └── reader.test.ts
+```
+
+---
+
+## Task 1: Scaffold server-ts package
+
+**Files:**
+- Create: `server-ts/package.json`
+- Create: `server-ts/tsconfig.json`
+- Create: `server-ts/vitest.config.ts`
+- Create: `server-ts/biome.json`
+- Create: `server-ts/.gitignore`
+- Create: `server-ts/src/index.ts`
+
+- [ ] **Step 1: Create directory and package.json**
+
+```bash
+mkdir -p server-ts/src
+```
+
+Create `server-ts/package.json`:
+
+```json
+{
+  "name": "@bolly/server",
+  "version": "1.0.0-alpha.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check": "tsc --noEmit && biome check src"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "smol-toml": "^1.3.1",
+    "ulid": "^2.3.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.8"
+  }
+}
+```
+
+- [ ] **Step 2: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"]
+}
+```
+
+- [ ] **Step 3: Create vitest.config.ts**
+
+```typescript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"],
+    },
+  },
+});
+```
+
+- [ ] **Step 4: Create biome.json**
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": { "enabled": true },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": { "noNonNullAssertion": "off" }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  }
+}
+```
+
+- [ ] **Step 5: Create .gitignore and initial index.ts**
+
+`server-ts/.gitignore`:
+
+```
+node_modules
+dist
+coverage
+*.log
+.env
+.DS_Store
+```
+
+`server-ts/src/index.ts`:
+
+```typescript
+export const VERSION = "1.0.0-alpha.0";
+```
+
+- [ ] **Step 6: Install dependencies and verify build**
+
+Run from `server-ts/`:
+
+```bash
+pnpm install
+pnpm check
+pnpm test
+```
+
+Expected: install succeeds; `check` passes; `test` reports "No test files found" (exit code 0 because vitest treats empty as non-failure with `run`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server-ts
+git commit -m "$(cat <<'EOF'
+chore(server-ts): scaffold TypeScript package for v1 backend
+
+Adds empty pnpm package with TypeScript, vitest, and biome configured.
+No runtime code yet — subsequent tasks fill in foundation modules.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Core type definitions
+
+**Files:**
+- Create: `server-ts/src/types.ts`
+- Create: `server-ts/src/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/types.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { EventSourceSchema, TriageDecisionSchema, BudgetStateSchema } from "./types.js";
+
+describe("EventSourceSchema", () => {
+  it("accepts the eight known sources", () => {
+    const sources = [
+      "user_msg",
+      "user_activity",
+      "email",
+      "calendar",
+      "scheduled",
+      "idle",
+      "skill_emit",
+      "instance_emit",
+    ];
+    for (const s of sources) {
+      expect(EventSourceSchema.parse(s)).toBe(s);
+    }
+  });
+
+  it("rejects an unknown source", () => {
+    expect(() => EventSourceSchema.parse("bogus")).toThrow();
+  });
+});
+
+describe("TriageDecisionSchema", () => {
+  it("accepts ignore, digest, escalate", () => {
+    for (const d of ["ignore", "digest", "escalate"]) {
+      expect(TriageDecisionSchema.parse(d)).toBe(d);
+    }
+  });
+
+  it("rejects any other value", () => {
+    expect(() => TriageDecisionSchema.parse("skip")).toThrow();
+  });
+});
+
+describe("BudgetStateSchema", () => {
+  it("accepts ok, tight, suppressed", () => {
+    for (const s of ["ok", "tight", "suppressed"]) {
+      expect(BudgetStateSchema.parse(s)).toBe(s);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `server-ts/`:
+
+```bash
+pnpm test src/types.test.ts
+```
+
+Expected: FAIL. vitest cannot find `./types.js` exports.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/types.ts`:
+
+```typescript
+import { z } from "zod";
+
+export const EventSourceSchema = z.enum([
+  "user_msg",
+  "user_activity",
+  "email",
+  "calendar",
+  "scheduled",
+  "idle",
+  "skill_emit",
+  "instance_emit",
+]);
+export type EventSource = z.infer<typeof EventSourceSchema>;
+
+export const EventSchema = z.object({
+  id: z.string().min(1),
+  user_id: z.string().min(1),
+  source: EventSourceSchema,
+  ts: z.number().int().nonnegative(),
+  payload: z.record(z.unknown()).default({}),
+  skill_hint: z.string().optional(),
+});
+export type Event = z.infer<typeof EventSchema>;
+
+export const TriageDecisionSchema = z.enum(["ignore", "digest", "escalate"]);
+export type TriageDecision = z.infer<typeof TriageDecisionSchema>;
+
+export const TriageOutcomeSchema = z.object({
+  decision: TriageDecisionSchema,
+  reason: z.string(),
+});
+export type TriageOutcome = z.infer<typeof TriageOutcomeSchema>;
+
+export const BudgetStateSchema = z.enum(["ok", "tight", "suppressed"]);
+export type BudgetState = z.infer<typeof BudgetStateSchema>;
+
+export const BudgetDailySchema = z.object({
+  day: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  calls: z.number().int().nonnegative().default(0),
+  tokens_in: z.number().int().nonnegative().default(0),
+  tokens_out: z.number().int().nonnegative().default(0),
+  dollars_spent: z.number().nonnegative().default(0),
+  cap_usd: z.number().positive(),
+  state: BudgetStateSchema.default("ok"),
+});
+export type BudgetDaily = z.infer<typeof BudgetDailySchema>;
+
+export const SkillFrontmatterSchema = z.object({
+  name: z.string().min(1),
+  created: z.string().optional(),
+  triggers: z.array(z.record(z.unknown())).default([]),
+  tools: z.array(z.string()).default([]),
+  enabled: z.boolean().default(true),
+});
+export type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;
+
+export const SkillSchema = z.object({
+  frontmatter: SkillFrontmatterSchema,
+  body: z.string(),
+  path: z.string(),
+});
+export type Skill = z.infer<typeof SkillSchema>;
+
+export const OutreachChannelSchema = z.enum(["push", "email", "digest"]);
+export type OutreachChannel = z.infer<typeof OutreachChannelSchema>;
+
+export const OutreachEntrySchema = z.object({
+  id: z.string().min(1),
+  ts: z.number().int().nonnegative(),
+  channel: OutreachChannelSchema,
+  title: z.string(),
+  body: z.string().optional(),
+  urgency: z.enum(["low", "medium", "high"]).default("medium"),
+  delivered: z.boolean(),
+  dedup_suppressed: z.boolean().default(false),
+});
+export type OutreachEntry = z.infer<typeof OutreachEntrySchema>;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/types.test.ts
+```
+
+Expected: PASS — 3 test blocks, all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/types.ts server-ts/src/types.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add core type schemas
+
+Defines Event, TriageOutcome, BudgetDaily, Skill, OutreachEntry
+using zod for runtime validation and type inference.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Filesystem path helpers
+
+**Files:**
+- Create: `server-ts/src/paths.ts`
+- Create: `server-ts/src/paths.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/paths.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import {
+  bollyHome,
+  instanceDir,
+  chatDir,
+  conversationFile,
+  skillsDir,
+  skillFile,
+  triageFile,
+  budgetDir,
+  budgetDailyFile,
+  outreachFile,
+  sharedDir,
+  sharedChannelDir,
+  sharedInstancesFile,
+} from "./paths.js";
+
+describe("paths", () => {
+  const home = "/tmp/bolly-test";
+
+  it("bollyHome returns the passed root", () => {
+    expect(bollyHome(home)).toBe(home);
+  });
+
+  it("instanceDir joins home + instances + slug", () => {
+    expect(instanceDir(home, "alice")).toBe("/tmp/bolly-test/instances/alice");
+  });
+
+  it("chatDir nests under instance/chats/chatId", () => {
+    expect(chatDir(home, "alice", "default")).toBe(
+      "/tmp/bolly-test/instances/alice/chats/default",
+    );
+  });
+
+  it("conversationFile lives inside chatDir", () => {
+    expect(conversationFile(home, "alice", "default")).toBe(
+      "/tmp/bolly-test/instances/alice/chats/default/conversation.json",
+    );
+  });
+
+  it("skillsDir is instances/{slug}/skills", () => {
+    expect(skillsDir(home, "alice")).toBe(
+      "/tmp/bolly-test/instances/alice/skills",
+    );
+  });
+
+  it("skillFile suffixes .md", () => {
+    expect(skillFile(home, "alice", "email-check")).toBe(
+      "/tmp/bolly-test/instances/alice/skills/email-check.md",
+    );
+  });
+
+  it("triageFile is instances/{slug}/triage.md", () => {
+    expect(triageFile(home, "alice")).toBe(
+      "/tmp/bolly-test/instances/alice/triage.md",
+    );
+  });
+
+  it("budgetDir is instances/{slug}/budget", () => {
+    expect(budgetDir(home, "alice")).toBe(
+      "/tmp/bolly-test/instances/alice/budget",
+    );
+  });
+
+  it("budgetDailyFile uses YYYY-MM-DD.json", () => {
+    expect(budgetDailyFile(home, "alice", "2026-04-22")).toBe(
+      "/tmp/bolly-test/instances/alice/budget/2026-04-22.json",
+    );
+  });
+
+  it("outreachFile is instances/{slug}/outreach.jsonl", () => {
+    expect(outreachFile(home, "alice")).toBe(
+      "/tmp/bolly-test/instances/alice/outreach.jsonl",
+    );
+  });
+
+  it("sharedDir is home/shared", () => {
+    expect(sharedDir(home)).toBe("/tmp/bolly-test/shared");
+  });
+
+  it("sharedChannelDir is home/shared/channel", () => {
+    expect(sharedChannelDir(home)).toBe("/tmp/bolly-test/shared/channel");
+  });
+
+  it("sharedInstancesFile is home/shared/instances.json", () => {
+    expect(sharedInstancesFile(home)).toBe(
+      "/tmp/bolly-test/shared/instances.json",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/paths.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/paths.ts`:
+
+```typescript
+import { join } from "node:path";
+
+export function bollyHome(home: string): string {
+  return home;
+}
+
+export function instanceDir(home: string, slug: string): string {
+  return join(home, "instances", slug);
+}
+
+export function chatDir(home: string, slug: string, chatId: string): string {
+  return join(instanceDir(home, slug), "chats", chatId);
+}
+
+export function conversationFile(home: string, slug: string, chatId: string): string {
+  return join(chatDir(home, slug, chatId), "conversation.json");
+}
+
+export function skillsDir(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "skills");
+}
+
+export function skillFile(home: string, slug: string, name: string): string {
+  return join(skillsDir(home, slug), `${name}.md`);
+}
+
+export function triageFile(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "triage.md");
+}
+
+export function budgetDir(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "budget");
+}
+
+export function budgetDailyFile(home: string, slug: string, day: string): string {
+  return join(budgetDir(home, slug), `${day}.json`);
+}
+
+export function outreachFile(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "outreach.jsonl");
+}
+
+export function settingsFile(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "settings.toml");
+}
+
+export function sharedDir(home: string): string {
+  return join(home, "shared");
+}
+
+export function sharedChannelDir(home: string): string {
+  return join(sharedDir(home), "channel");
+}
+
+export function sharedInstancesFile(home: string): string {
+  return join(sharedDir(home), "instances.json");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/paths.test.ts
+```
+
+Expected: PASS — 13 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/paths.ts server-ts/src/paths.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add filesystem path helpers
+
+Pure path-join helpers for every file shape documented in the spec:
+instance/, chats/, skills/, budget/, triage.md, outreach.jsonl, shared/.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Atomic file write utility
+
+**Files:**
+- Create: `server-ts/src/fs-atomic.ts`
+- Create: `server-ts/src/fs-atomic.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/fs-atomic.test.ts`:
+
+```typescript
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { atomicWrite } from "./fs-atomic.js";
+
+describe("atomicWrite", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "bolly-atomic-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes content to the target path", async () => {
+    const target = join(dir, "hello.txt");
+    await atomicWrite(target, "hello world");
+    const contents = await readFile(target, "utf8");
+    expect(contents).toBe("hello world");
+  });
+
+  it("creates parent directories if missing", async () => {
+    const target = join(dir, "nested", "deep", "file.txt");
+    await atomicWrite(target, "ok");
+    const contents = await readFile(target, "utf8");
+    expect(contents).toBe("ok");
+  });
+
+  it("overwrites an existing file", async () => {
+    const target = join(dir, "overwrite.txt");
+    await writeFile(target, "old");
+    await atomicWrite(target, "new");
+    const contents = await readFile(target, "utf8");
+    expect(contents).toBe("new");
+  });
+
+  it("cleans up its .tmp file on success", async () => {
+    const target = join(dir, "cleanup.txt");
+    await atomicWrite(target, "body");
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(dir);
+    expect(entries).toEqual(["cleanup.txt"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/fs-atomic.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/fs-atomic.ts`:
+
+```typescript
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+/**
+ * Write body to path atomically by writing to a .tmp sibling and renaming.
+ * Mirrors the Rust backend's write-tmp-then-rename pattern.
+ */
+export async function atomicWrite(
+  path: string,
+  body: string | Uint8Array,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, body);
+  await rename(tmp, path);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/fs-atomic.test.ts
+```
+
+Expected: PASS — 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/fs-atomic.ts server-ts/src/fs-atomic.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add atomic file write helper
+
+write-tmp-then-rename, creates parent dirs, overwrites safely.
+Matches the existing Rust backend pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Typed JSON file helpers
+
+**Files:**
+- Create: `server-ts/src/json-file.ts`
+- Create: `server-ts/src/json-file.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/json-file.test.ts`:
+
+```typescript
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { readJson, writeJson } from "./json-file.js";
+
+const PersonSchema = z.object({ name: z.string(), age: z.number() });
+
+describe("readJson", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "bolly-json-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("parses a valid JSON file through the schema", async () => {
+    const f = join(dir, "person.json");
+    await writeFile(f, JSON.stringify({ name: "alice", age: 30 }));
+    const result = await readJson(f, PersonSchema);
+    expect(result).toEqual({ name: "alice", age: 30 });
+  });
+
+  it("returns null when the file is missing", async () => {
+    const f = join(dir, "missing.json");
+    const result = await readJson(f, PersonSchema);
+    expect(result).toBeNull();
+  });
+
+  it("throws when the JSON is malformed", async () => {
+    const f = join(dir, "broken.json");
+    await writeFile(f, "{ not valid");
+    await expect(readJson(f, PersonSchema)).rejects.toThrow(/parse/i);
+  });
+
+  it("throws when the shape fails schema validation", async () => {
+    const f = join(dir, "wrong.json");
+    await writeFile(f, JSON.stringify({ name: "alice", age: "thirty" }));
+    await expect(readJson(f, PersonSchema)).rejects.toThrow();
+  });
+});
+
+describe("writeJson", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "bolly-json-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes a pretty-printed JSON file that round-trips", async () => {
+    const f = join(dir, "round.json");
+    await writeJson(f, { name: "bob", age: 25 });
+    const roundTripped = await readJson(f, PersonSchema);
+    expect(roundTripped).toEqual({ name: "bob", age: 25 });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/json-file.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/json-file.ts`:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import type { ZodSchema } from "zod";
+import { atomicWrite } from "./fs-atomic.js";
+
+/**
+ * Read a JSON file and validate it against a zod schema.
+ * Returns null if the file does not exist.
+ * Throws on parse errors or schema failures.
+ */
+export async function readJson<T>(
+  path: string,
+  schema: ZodSchema<T>,
+): Promise<T | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`failed to parse JSON at ${path}: ${(err as Error).message}`);
+  }
+
+  return schema.parse(parsed);
+}
+
+/**
+ * Write a value as pretty JSON to path, atomically.
+ */
+export async function writeJson<T>(path: string, value: T): Promise<void> {
+  await atomicWrite(path, JSON.stringify(value, null, 2));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/json-file.test.ts
+```
+
+Expected: PASS — 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/json-file.ts server-ts/src/json-file.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add schema-validated JSON file helpers
+
+readJson returns null for missing files, throws on parse/schema errors.
+writeJson writes atomically via fs-atomic.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: TOML file helpers
+
+**Files:**
+- Create: `server-ts/src/toml-file.ts`
+- Create: `server-ts/src/toml-file.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/toml-file.test.ts`:
+
+```typescript
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { readToml } from "./toml-file.js";
+
+const ConfigSchema = z.object({
+  name: z.string(),
+  nested: z.object({ value: z.number() }),
+});
+
+describe("readToml", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "bolly-toml-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("parses a valid TOML file through the schema", async () => {
+    const f = join(dir, "config.toml");
+    await writeFile(f, 'name = "alice"\n[nested]\nvalue = 42\n');
+    const result = await readToml(f, ConfigSchema);
+    expect(result).toEqual({ name: "alice", nested: { value: 42 } });
+  });
+
+  it("returns null when the file is missing", async () => {
+    const f = join(dir, "missing.toml");
+    const result = await readToml(f, ConfigSchema);
+    expect(result).toBeNull();
+  });
+
+  it("throws when the TOML is malformed", async () => {
+    const f = join(dir, "broken.toml");
+    await writeFile(f, "not = [ valid");
+    await expect(readToml(f, ConfigSchema)).rejects.toThrow(/parse/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/toml-file.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/toml-file.ts`:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { parse as parseToml } from "smol-toml";
+import type { ZodSchema } from "zod";
+
+/**
+ * Read a TOML file and validate it against a zod schema.
+ * Returns null if the file does not exist.
+ */
+export async function readToml<T>(
+  path: string,
+  schema: ZodSchema<T>,
+): Promise<T | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseToml(raw);
+  } catch (err) {
+    throw new Error(`failed to parse TOML at ${path}: ${(err as Error).message}`);
+  }
+
+  return schema.parse(parsed);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/toml-file.test.ts
+```
+
+Expected: PASS — 3 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/toml-file.ts server-ts/src/toml-file.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add TOML read helper with schema validation
+
+Read-only for now; write-side not needed yet (skills use markdown,
+settings are infrequently written and formatting is not critical).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Budget state calculator
+
+**Files:**
+- Create: `server-ts/src/budget/state.ts`
+- Create: `server-ts/src/budget/state.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/budget/state.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { computeState, TIGHT_THRESHOLD } from "./state.js";
+
+describe("computeState", () => {
+  it("returns ok when spend is below 70% of cap", () => {
+    expect(computeState(0.5, 2.0)).toBe("ok");
+    expect(computeState(1.39, 2.0)).toBe("ok");
+    expect(computeState(0, 2.0)).toBe("ok");
+  });
+
+  it("returns tight at exactly 70% of cap", () => {
+    expect(computeState(1.4, 2.0)).toBe("tight");
+  });
+
+  it("returns tight when spend is in [70%, 100%)", () => {
+    expect(computeState(1.5, 2.0)).toBe("tight");
+    expect(computeState(1.999, 2.0)).toBe("tight");
+  });
+
+  it("returns suppressed at exactly the cap", () => {
+    expect(computeState(2.0, 2.0)).toBe("suppressed");
+  });
+
+  it("returns suppressed above the cap", () => {
+    expect(computeState(3.0, 2.0)).toBe("suppressed");
+  });
+
+  it("exposes TIGHT_THRESHOLD as 0.7", () => {
+    expect(TIGHT_THRESHOLD).toBe(0.7);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/budget/state.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/budget/state.ts`:
+
+```typescript
+import type { BudgetState } from "../types.js";
+
+export const TIGHT_THRESHOLD = 0.7;
+
+/**
+ * Classify current spend vs cap into one of three budget states.
+ * Pure function; no side effects.
+ */
+export function computeState(dollarsSpent: number, capUsd: number): BudgetState {
+  if (capUsd <= 0) return "suppressed";
+  const ratio = dollarsSpent / capUsd;
+  if (ratio >= 1) return "suppressed";
+  if (ratio >= TIGHT_THRESHOLD) return "tight";
+  return "ok";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/budget/state.test.ts
+```
+
+Expected: PASS — 6 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/budget/state.ts server-ts/src/budget/state.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add budget state calculator
+
+Pure classifier: ok < 70%, tight 70-99%, suppressed at/above 100%.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Budget daily ledger
+
+**Files:**
+- Create: `server-ts/src/budget/ledger.ts`
+- Create: `server-ts/src/budget/ledger.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/budget/ledger.test.ts`:
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadDaily, recordSpend, todayUtc } from "./ledger.js";
+
+describe("todayUtc", () => {
+  it("formats a Date as YYYY-MM-DD in UTC", () => {
+    const d = new Date(Date.UTC(2026, 3, 22, 5, 30)); // month is 0-indexed
+    expect(todayUtc(d)).toBe("2026-04-22");
+  });
+
+  it("rolls over at UTC midnight, not local", () => {
+    const d = new Date(Date.UTC(2026, 3, 22, 23, 59));
+    expect(todayUtc(d)).toBe("2026-04-22");
+    const after = new Date(Date.UTC(2026, 3, 23, 0, 1));
+    expect(todayUtc(after)).toBe("2026-04-23");
+  });
+});
+
+describe("loadDaily", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-ledger-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns a fresh ledger with defaults when file missing", async () => {
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger).toEqual({
+      day: "2026-04-22",
+      calls: 0,
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars_spent: 0,
+      cap_usd: 2.0,
+      state: "ok",
+    });
+  });
+
+  it("returns the persisted ledger when file exists", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 100,
+      tokens_out: 20,
+      dollars: 0.5,
+    });
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.calls).toBe(1);
+    expect(ledger.tokens_in).toBe(100);
+    expect(ledger.tokens_out).toBe(20);
+    expect(ledger.dollars_spent).toBeCloseTo(0.5);
+  });
+});
+
+describe("recordSpend", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-ledger-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("accumulates spend across calls", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 100,
+      tokens_out: 10,
+      dollars: 0.3,
+    });
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 200,
+      tokens_out: 30,
+      dollars: 0.5,
+    });
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.calls).toBe(2);
+    expect(ledger.tokens_in).toBe(300);
+    expect(ledger.tokens_out).toBe(40);
+    expect(ledger.dollars_spent).toBeCloseTo(0.8);
+  });
+
+  it("updates state when spend crosses tight threshold", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 1.5,
+    });
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.state).toBe("tight");
+  });
+
+  it("updates state to suppressed when spend reaches cap", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 2.0,
+    });
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.state).toBe("suppressed");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/budget/ledger.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/budget/ledger.ts`:
+
+```typescript
+import { budgetDailyFile } from "../paths.js";
+import { readJson, writeJson } from "../json-file.js";
+import { BudgetDailySchema, type BudgetDaily } from "../types.js";
+import { computeState } from "./state.js";
+
+export function todayUtc(d: Date = new Date()): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export async function loadDaily(
+  home: string,
+  slug: string,
+  day: string,
+  capUsd: number,
+): Promise<BudgetDaily> {
+  const path = budgetDailyFile(home, slug, day);
+  const existing = await readJson(path, BudgetDailySchema);
+  if (existing) return existing;
+
+  return {
+    day,
+    calls: 0,
+    tokens_in: 0,
+    tokens_out: 0,
+    dollars_spent: 0,
+    cap_usd: capUsd,
+    state: "ok",
+  };
+}
+
+export type SpendDelta = {
+  tokens_in: number;
+  tokens_out: number;
+  dollars: number;
+};
+
+export async function recordSpend(
+  home: string,
+  slug: string,
+  day: string,
+  capUsd: number,
+  delta: SpendDelta,
+): Promise<BudgetDaily> {
+  const current = await loadDaily(home, slug, day, capUsd);
+  const next: BudgetDaily = {
+    day,
+    calls: current.calls + 1,
+    tokens_in: current.tokens_in + delta.tokens_in,
+    tokens_out: current.tokens_out + delta.tokens_out,
+    dollars_spent: current.dollars_spent + delta.dollars,
+    cap_usd: capUsd,
+    state: computeState(current.dollars_spent + delta.dollars, capUsd),
+  };
+  await writeJson(budgetDailyFile(home, slug, day), next);
+  return next;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/budget/ledger.test.ts
+```
+
+Expected: PASS — 7 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/budget/ledger.ts server-ts/src/budget/ledger.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add budget daily ledger
+
+loadDaily reads or initializes the day's ledger; recordSpend accumulates
+deltas and recomputes state. All writes atomic via json-file.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: chargeAndCall LLM wrapper
+
+**Files:**
+- Create: `server-ts/src/budget/charge-and-call.ts`
+- Create: `server-ts/src/budget/charge-and-call.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/budget/charge-and-call.test.ts`:
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chargeAndCall, type CallOutcome } from "./charge-and-call.js";
+
+describe("chargeAndCall", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-cac-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("invokes fn with state ok when ledger is empty", async () => {
+    let seenState: string | null = null;
+    const result = await chargeAndCall(
+      { home, slug: "alice", day: "2026-04-22", capUsd: 2.0, tier: 3 },
+      async (state) => {
+        seenState = state;
+        return { ok: true, usage: { tokens_in: 10, tokens_out: 5, dollars: 0.01 } };
+      },
+    );
+    expect(seenState).toBe("ok");
+    expect((result as CallOutcome<unknown>).downgraded).toBeUndefined();
+  });
+
+  it("records spend after the call", async () => {
+    await chargeAndCall(
+      { home, slug: "alice", day: "2026-04-22", capUsd: 2.0, tier: 2 },
+      async () => ({ ok: true, usage: { tokens_in: 100, tokens_out: 20, dollars: 0.05 } }),
+    );
+    const { loadDaily } = await import("./ledger.js");
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.calls).toBe(1);
+    expect(ledger.dollars_spent).toBeCloseTo(0.05);
+  });
+
+  it("downgrades tier 3 when state is suppressed without calling fn", async () => {
+    // Seed ledger to suppressed
+    const { recordSpend } = await import("./ledger.js");
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 2.5,
+    });
+
+    let fnCalled = false;
+    const result = await chargeAndCall(
+      { home, slug: "alice", day: "2026-04-22", capUsd: 2.0, tier: 3 },
+      async () => {
+        fnCalled = true;
+        return { ok: true, usage: { tokens_in: 0, tokens_out: 0, dollars: 0 } };
+      },
+    );
+    expect(fnCalled).toBe(false);
+    expect(result).toEqual({ downgraded: true, reason: "budget_cap" });
+  });
+
+  it("allows tier 2 calls even when suppressed (triage is cheap)", async () => {
+    const { recordSpend } = await import("./ledger.js");
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 2.5,
+    });
+
+    let fnCalled = false;
+    await chargeAndCall(
+      { home, slug: "alice", day: "2026-04-22", capUsd: 2.0, tier: 2 },
+      async () => {
+        fnCalled = true;
+        return { ok: true, usage: { tokens_in: 10, tokens_out: 5, dollars: 0.001 } };
+      },
+    );
+    expect(fnCalled).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/budget/charge-and-call.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/budget/charge-and-call.ts`:
+
+```typescript
+import type { BudgetState } from "../types.js";
+import { loadDaily, recordSpend, type SpendDelta } from "./ledger.js";
+
+export type ChargeContext = {
+  home: string;
+  slug: string;
+  day: string;
+  capUsd: number;
+  tier: 2 | 3;
+};
+
+export type CallSuccess<T> = {
+  ok: true;
+  value?: T;
+  usage: SpendDelta;
+};
+
+export type CallDowngraded = {
+  downgraded: true;
+  reason: string;
+};
+
+export type CallOutcome<T> = CallSuccess<T> | CallDowngraded;
+
+/**
+ * Wraps an LLM call with budget enforcement.
+ * - Loads today's ledger.
+ * - For tier 3 when state is suppressed, returns a downgraded outcome without invoking fn.
+ * - Otherwise calls fn, records spend, returns success.
+ */
+export async function chargeAndCall<T>(
+  ctx: ChargeContext,
+  fn: (state: BudgetState) => Promise<CallSuccess<T>>,
+): Promise<CallOutcome<T>> {
+  const ledger = await loadDaily(ctx.home, ctx.slug, ctx.day, ctx.capUsd);
+
+  if (ctx.tier === 3 && ledger.state === "suppressed") {
+    return { downgraded: true, reason: "budget_cap" };
+  }
+
+  const result = await fn(ledger.state);
+  await recordSpend(ctx.home, ctx.slug, ctx.day, ctx.capUsd, result.usage);
+  return result;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/budget/charge-and-call.test.ts
+```
+
+Expected: PASS — 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/budget/charge-and-call.ts server-ts/src/budget/charge-and-call.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add chargeAndCall LLM wrapper
+
+Gates LLM invocations against the daily budget ledger.
+Tier 3 + suppressed = downgraded outcome, fn not invoked.
+Tier 2 always runs (triage is cheap and needed even under budget pressure).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Per-minute throttle
+
+**Files:**
+- Create: `server-ts/src/budget/throttle.ts`
+- Create: `server-ts/src/budget/throttle.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/budget/throttle.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { Throttle } from "./throttle.js";
+
+describe("Throttle", () => {
+  it("allows the first N calls within a window", () => {
+    const t = new Throttle({ maxCalls: 5, windowMs: 60_000 });
+    const start = 1_000_000;
+    for (let i = 0; i < 5; i++) {
+      expect(t.check("alice", start + i * 100)).toBe(true);
+    }
+  });
+
+  it("rejects the N+1st call within the window", () => {
+    const t = new Throttle({ maxCalls: 3, windowMs: 60_000 });
+    const start = 1_000_000;
+    t.check("alice", start);
+    t.check("alice", start + 1);
+    t.check("alice", start + 2);
+    expect(t.check("alice", start + 3)).toBe(false);
+  });
+
+  it("tracks quota independently per user", () => {
+    const t = new Throttle({ maxCalls: 2, windowMs: 60_000 });
+    const now = 1_000_000;
+    t.check("alice", now);
+    t.check("alice", now + 1);
+    expect(t.check("alice", now + 2)).toBe(false);
+    expect(t.check("bob", now + 2)).toBe(true);
+  });
+
+  it("decays entries outside the window", () => {
+    const t = new Throttle({ maxCalls: 2, windowMs: 60_000 });
+    const now = 1_000_000;
+    t.check("alice", now);
+    t.check("alice", now + 30_000);
+    // Old entry still counts — third call blocked
+    expect(t.check("alice", now + 40_000)).toBe(false);
+    // After window passes, first entry drops out
+    expect(t.check("alice", now + 65_000)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/budget/throttle.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/budget/throttle.ts`:
+
+```typescript
+export type ThrottleConfig = {
+  maxCalls: number;
+  windowMs: number;
+};
+
+/**
+ * Rolling-window per-user throttle. In-memory only — suitable for the
+ * single-mind-per-user model where there's one process per user.
+ */
+export class Throttle {
+  private readonly buckets = new Map<string, number[]>();
+
+  constructor(private readonly config: ThrottleConfig) {}
+
+  /**
+   * Returns true if the call is allowed (and records it).
+   * Returns false if the call would exceed the window's max.
+   */
+  check(userId: string, nowMs: number): boolean {
+    const cutoff = nowMs - this.config.windowMs;
+    const existing = this.buckets.get(userId) ?? [];
+    const pruned = existing.filter((ts) => ts > cutoff);
+
+    if (pruned.length >= this.config.maxCalls) {
+      this.buckets.set(userId, pruned);
+      return false;
+    }
+
+    pruned.push(nowMs);
+    this.buckets.set(userId, pruned);
+    return true;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/budget/throttle.test.ts
+```
+
+Expected: PASS — 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/budget/throttle.ts server-ts/src/budget/throttle.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add rolling-window per-user throttle
+
+In-memory defense against runaway skills. 5 tier-3 calls per minute
+per user is the intended default; values are passed in at construction.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Skill frontmatter parser
+
+**Files:**
+- Create: `server-ts/src/skills/parse.ts`
+- Create: `server-ts/src/skills/parse.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/skills/parse.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { parseSkill } from "./parse.js";
+
+const VALID_SKILL = `---
+name: email-morning-check
+created: 2026-04-22
+triggers:
+  - scheduled: "every weekday at 8am"
+  - event: "email arrives with 'urgent' in subject"
+tools:
+  - read_email
+  - send_push
+enabled: true
+---
+
+When triggered, read unread emails since last check.
+Summarize anything the user would care about.
+`;
+
+describe("parseSkill", () => {
+  it("parses a well-formed skill into frontmatter + body", () => {
+    const skill = parseSkill(VALID_SKILL, "/instances/alice/skills/email.md");
+    expect(skill.frontmatter.name).toBe("email-morning-check");
+    expect(skill.frontmatter.tools).toEqual(["read_email", "send_push"]);
+    expect(skill.frontmatter.enabled).toBe(true);
+    expect(skill.frontmatter.triggers).toHaveLength(2);
+    expect(skill.body).toContain("When triggered");
+    expect(skill.path).toBe("/instances/alice/skills/email.md");
+  });
+
+  it("applies defaults for missing optional fields", () => {
+    const minimal = `---
+name: minimal
+---
+
+body here
+`;
+    const skill = parseSkill(minimal, "/x.md");
+    expect(skill.frontmatter.enabled).toBe(true);
+    expect(skill.frontmatter.tools).toEqual([]);
+    expect(skill.frontmatter.triggers).toEqual([]);
+  });
+
+  it("throws when frontmatter is absent", () => {
+    expect(() => parseSkill("no frontmatter here", "/x.md")).toThrow(/frontmatter/i);
+  });
+
+  it("throws when the required name field is missing", () => {
+    const bad = `---
+description: anonymous skill
+---
+
+body
+`;
+    expect(() => parseSkill(bad, "/x.md")).toThrow();
+  });
+
+  it("respects enabled: false", () => {
+    const disabled = `---
+name: sleeping
+enabled: false
+---
+
+not right now
+`;
+    const skill = parseSkill(disabled, "/x.md");
+    expect(skill.frontmatter.enabled).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/skills/parse.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/skills/parse.ts`:
+
+```typescript
+import matter from "gray-matter";
+import { SkillFrontmatterSchema, type Skill } from "../types.js";
+
+/**
+ * Parse a skill file (YAML frontmatter + markdown body) into a Skill.
+ * Throws if frontmatter is missing or does not match the schema.
+ */
+export function parseSkill(contents: string, path: string): Skill {
+  if (!contents.trimStart().startsWith("---")) {
+    throw new Error(`skill at ${path} is missing YAML frontmatter`);
+  }
+
+  const { data, content } = matter(contents);
+  const frontmatter = SkillFrontmatterSchema.parse(data);
+
+  return {
+    frontmatter,
+    body: content.trimStart(),
+    path,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/skills/parse.test.ts
+```
+
+Expected: PASS — 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/skills/parse.ts server-ts/src/skills/parse.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add skill frontmatter parser
+
+Uses gray-matter for YAML + body split, zod for schema validation.
+Rejects files without frontmatter or without a name.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Skill directory loader
+
+**Files:**
+- Create: `server-ts/src/skills/loader.ts`
+- Create: `server-ts/src/skills/loader.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/skills/loader.test.ts`:
+
+```typescript
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadSkills } from "./loader.js";
+
+async function seed(home: string, slug: string, name: string, body: string): Promise<void> {
+  const dir = join(home, "instances", slug, "skills");
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, `${name}.md`), body);
+}
+
+describe("loadSkills", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-skills-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns an empty array when no skills directory exists", async () => {
+    const skills = await loadSkills(home, "alice");
+    expect(skills).toEqual([]);
+  });
+
+  it("loads all .md files from the skills directory", async () => {
+    await seed(home, "alice", "one", "---\nname: one\n---\n\nbody one");
+    await seed(home, "alice", "two", "---\nname: two\n---\n\nbody two");
+    const skills = await loadSkills(home, "alice");
+    const names = skills.map((s) => s.frontmatter.name).sort();
+    expect(names).toEqual(["one", "two"]);
+  });
+
+  it("skips non-.md files", async () => {
+    await seed(home, "alice", "real", "---\nname: real\n---\n\nbody");
+    await writeFile(
+      join(home, "instances", "alice", "skills", "readme.txt"),
+      "not a skill",
+    );
+    const skills = await loadSkills(home, "alice");
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.frontmatter.name).toBe("real");
+  });
+
+  it("filters out disabled skills when enabledOnly=true", async () => {
+    await seed(home, "alice", "on", "---\nname: on\nenabled: true\n---\n\nbody");
+    await seed(home, "alice", "off", "---\nname: off\nenabled: false\n---\n\nbody");
+    const enabled = await loadSkills(home, "alice", { enabledOnly: true });
+    expect(enabled.map((s) => s.frontmatter.name)).toEqual(["on"]);
+  });
+
+  it("returns all skills when enabledOnly omitted", async () => {
+    await seed(home, "alice", "on", "---\nname: on\nenabled: true\n---\n\nbody");
+    await seed(home, "alice", "off", "---\nname: off\nenabled: false\n---\n\nbody");
+    const all = await loadSkills(home, "alice");
+    expect(all).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/skills/loader.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/skills/loader.ts`:
+
+```typescript
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { skillsDir } from "../paths.js";
+import type { Skill } from "../types.js";
+import { parseSkill } from "./parse.js";
+
+export type LoadSkillsOptions = {
+  enabledOnly?: boolean;
+};
+
+/**
+ * Load all skill .md files from an instance's skills directory.
+ * Returns [] if the directory does not exist.
+ */
+export async function loadSkills(
+  home: string,
+  slug: string,
+  opts: LoadSkillsOptions = {},
+): Promise<Skill[]> {
+  const dir = skillsDir(home, slug);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const results: Skill[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".md")) continue;
+    const full = join(dir, name);
+    const raw = await readFile(full, "utf8");
+    const skill = parseSkill(raw, full);
+    if (opts.enabledOnly && !skill.frontmatter.enabled) continue;
+    results.push(skill);
+  }
+  return results;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/skills/loader.test.ts
+```
+
+Expected: PASS — 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/skills/loader.ts server-ts/src/skills/loader.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add skill directory loader
+
+Reads all .md files from instances/{slug}/skills/.
+Optional enabledOnly flag filters out disabled skills.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Triage rules reader
+
+**Files:**
+- Create: `server-ts/src/triage/rules.ts`
+- Create: `server-ts/src/triage/rules.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/triage/rules.test.ts`:
+
+```typescript
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadTriageRules, DEFAULT_TRIAGE_TEMPLATE } from "./rules.js";
+
+describe("loadTriageRules", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-triage-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns the default template when triage.md is missing", async () => {
+    const rules = await loadTriageRules(home, "alice");
+    expect(rules).toBe(DEFAULT_TRIAGE_TEMPLATE);
+  });
+
+  it("returns the raw file contents when triage.md exists", async () => {
+    const dir = join(home, "instances", "alice");
+    await mkdir(dir, { recursive: true });
+    const body = "# My rules\n\nAlways digest newsletters.";
+    await writeFile(join(dir, "triage.md"), body);
+    const rules = await loadTriageRules(home, "alice");
+    expect(rules).toBe(body);
+  });
+
+  it("DEFAULT_TRIAGE_TEMPLATE contains the word Default", () => {
+    expect(DEFAULT_TRIAGE_TEMPLATE).toMatch(/default/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/triage/rules.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/triage/rules.ts`:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { triageFile } from "../paths.js";
+
+export const DEFAULT_TRIAGE_TEMPLATE = `# Triage rules
+
+Default: unless matched below, ignore.
+
+## Always escalate
+- User sent a message in the app
+- Email or event marked urgent
+- A skill I installed explicitly asks for escalation
+
+## Always digest
+- Newsletter emails
+- Notification-only emails
+- Calendar changes in the past
+
+## Quiet hours
+- Between 22:00 and 07:00: only escalate if "emergency" in subject
+`;
+
+/**
+ * Read the user's triage rules file. Returns the default template when
+ * the file is missing — the mind will overwrite it once the user expresses
+ * preferences.
+ */
+export async function loadTriageRules(home: string, slug: string): Promise<string> {
+  try {
+    return await readFile(triageFile(home, slug), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return DEFAULT_TRIAGE_TEMPLATE;
+    }
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/triage/rules.test.ts
+```
+
+Expected: PASS — 3 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/triage/rules.ts server-ts/src/triage/rules.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add triage rules reader
+
+Returns the DEFAULT_TRIAGE_TEMPLATE when the user has not yet customized
+their rules. The mind rewrites triage.md in response to user chat.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Triage prompt builder
+
+**Files:**
+- Create: `server-ts/src/triage/prompt.ts`
+- Create: `server-ts/src/triage/prompt.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/triage/prompt.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import type { Event } from "../types.js";
+import { buildTriagePrompt } from "./prompt.js";
+
+const EVENT: Event = {
+  id: "01JKM000000000000000000000",
+  user_id: "alice",
+  source: "email",
+  ts: 1714000000000,
+  payload: { subject: "Q2 review", from: "boss@corp.com" },
+};
+
+describe("buildTriagePrompt", () => {
+  it("includes soul, mood, budget, triage rules, and the event", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "Bolly is calm and attentive.",
+      mood: "focused",
+      budgetState: "ok",
+      dollarsSpent: 0.42,
+      capUsd: 2.0,
+      triageRules: "# rules\n- urgent email -> escalate",
+      event: EVENT,
+      recentOutreach: [],
+    });
+
+    expect(prompt).toContain("<soul>Bolly is calm and attentive.</soul>");
+    expect(prompt).toContain("<mood>focused</mood>");
+    expect(prompt).toContain("0.42/2.00");
+    expect(prompt).toContain("ok");
+    expect(prompt).toContain("urgent email -> escalate");
+    expect(prompt).toContain("Q2 review");
+  });
+
+  it("adds tightening directive when state is tight", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "tight",
+      dollarsSpent: 1.5,
+      capUsd: 2.0,
+      triageRules: "",
+      event: EVENT,
+      recentOutreach: [],
+    });
+    expect(prompt).toContain("Only escalate if truly urgent");
+  });
+
+  it("adds suppression directive when state is suppressed", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "suppressed",
+      dollarsSpent: 2.0,
+      capUsd: 2.0,
+      triageRules: "",
+      event: EVENT,
+      recentOutreach: [],
+    });
+    expect(prompt).toContain("budget cap reached");
+  });
+
+  it("includes the last N outreach entries for self-regulation context", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "ok",
+      dollarsSpent: 0,
+      capUsd: 2.0,
+      triageRules: "",
+      event: EVENT,
+      recentOutreach: [
+        { channel: "push", title: "reminder", ts: 1713999999000, urgency: "medium" },
+        { channel: "email", title: "digest", ts: 1713999998000, urgency: "low" },
+      ],
+    });
+    expect(prompt).toContain("push: reminder");
+    expect(prompt).toContain("email: digest");
+  });
+
+  it("asks for the single-line response format", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "ok",
+      dollarsSpent: 0,
+      capUsd: 2.0,
+      triageRules: "",
+      event: EVENT,
+      recentOutreach: [],
+    });
+    expect(prompt).toMatch(/DECISION=.*REASON=/);
+  });
+
+  it("truncates large event payloads", () => {
+    const bigEvent: Event = {
+      ...EVENT,
+      payload: { body: "x".repeat(5000) },
+    };
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "ok",
+      dollarsSpent: 0,
+      capUsd: 2.0,
+      triageRules: "",
+      event: bigEvent,
+      recentOutreach: [],
+    });
+    expect(prompt.length).toBeLessThan(6000);
+    expect(prompt).toContain("[truncated]");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/triage/prompt.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/triage/prompt.ts`:
+
+```typescript
+import type { BudgetState, Event } from "../types.js";
+
+export type OutreachHint = {
+  channel: "push" | "email" | "digest";
+  title: string;
+  ts: number;
+  urgency: "low" | "medium" | "high";
+};
+
+export type TriagePromptInputs = {
+  soulSnippet: string;
+  mood: string;
+  budgetState: BudgetState;
+  dollarsSpent: number;
+  capUsd: number;
+  triageRules: string;
+  event: Event;
+  recentOutreach: OutreachHint[];
+};
+
+const EVENT_PAYLOAD_MAX = 1024;
+
+function truncateJson(value: unknown, limit: number): string {
+  const serialized = JSON.stringify(value);
+  if (serialized.length <= limit) return serialized;
+  return `${serialized.slice(0, limit)}[truncated]`;
+}
+
+function budgetDirective(state: BudgetState): string {
+  if (state === "tight") return "Only escalate if truly urgent.";
+  if (state === "suppressed") return "budget cap reached — prefer digest.";
+  return "";
+}
+
+export function buildTriagePrompt(inputs: TriagePromptInputs): string {
+  const {
+    soulSnippet,
+    mood,
+    budgetState,
+    dollarsSpent,
+    capUsd,
+    triageRules,
+    event,
+    recentOutreach,
+  } = inputs;
+
+  const outreachLines = recentOutreach
+    .map((o) => `  - ${o.channel}: ${o.title} (${o.urgency})`)
+    .join("\n");
+
+  const directive = budgetDirective(budgetState);
+
+  return `You are the triage layer for Bolly. Decide: ignore | digest | escalate.
+
+<soul>${soulSnippet}</soul>
+<mood>${mood}</mood>
+<budget_state>${dollarsSpent.toFixed(2)}/${capUsd.toFixed(2)} — ${budgetState}</budget_state>
+${directive ? `<directive>${directive}</directive>\n` : ""}
+<triage_rules>
+${triageRules}
+</triage_rules>
+
+<recent_outreach>
+${outreachLines || "  (none)"}
+</recent_outreach>
+
+<event source="${event.source}" id="${event.id}" ts="${event.ts}">
+${truncateJson(event.payload, EVENT_PAYLOAD_MAX)}
+</event>
+
+Respond with exactly one line:
+DECISION=<ignore|digest|escalate> REASON=<short sentence>`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/triage/prompt.test.ts
+```
+
+Expected: PASS — 6 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/triage/prompt.ts server-ts/src/triage/prompt.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add triage prompt string builder
+
+Assembles the Haiku prompt from soul/mood/budget/rules/event/recent-outreach.
+Adds directive line when budget state is tight or suppressed.
+Truncates large event payloads to keep the prompt under 2KB.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Outreach audit appender
+
+**Files:**
+- Create: `server-ts/src/outreach/audit.ts`
+- Create: `server-ts/src/outreach/audit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/outreach/audit.test.ts`:
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendOutreach, readRecentOutreach } from "./audit.js";
+import type { OutreachEntry } from "../types.js";
+
+function entry(id: string, ts: number, title = `event-${id}`): OutreachEntry {
+  return {
+    id,
+    ts,
+    channel: "push",
+    title,
+    urgency: "medium",
+    delivered: true,
+    dedup_suppressed: false,
+  };
+}
+
+describe("appendOutreach + readRecentOutreach", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-outreach-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns an empty list when the file is absent", async () => {
+    const entries = await readRecentOutreach(home, "alice", 10);
+    expect(entries).toEqual([]);
+  });
+
+  it("appends entries as JSON lines", async () => {
+    await appendOutreach(home, "alice", entry("a", 100));
+    await appendOutreach(home, "alice", entry("b", 200));
+    const entries = await readRecentOutreach(home, "alice", 10);
+    expect(entries.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("returns only the last N entries, newest last", async () => {
+    for (let i = 0; i < 5; i++) {
+      await appendOutreach(home, "alice", entry(`e${i}`, 1000 + i));
+    }
+    const entries = await readRecentOutreach(home, "alice", 3);
+    expect(entries.map((e) => e.id)).toEqual(["e2", "e3", "e4"]);
+  });
+
+  it("tolerates and skips malformed lines", async () => {
+    // Write a broken line directly, then a good one through the API
+    const { appendFile, mkdir } = await import("node:fs/promises");
+    const dir = join(home, "instances", "alice");
+    await mkdir(dir, { recursive: true });
+    await appendFile(join(dir, "outreach.jsonl"), "{ not valid json\n");
+    await appendOutreach(home, "alice", entry("good", 500));
+    const entries = await readRecentOutreach(home, "alice", 10);
+    expect(entries.map((e) => e.id)).toEqual(["good"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/outreach/audit.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/outreach/audit.ts`:
+
+```typescript
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { OutreachEntrySchema, type OutreachEntry } from "../types.js";
+import { outreachFile } from "../paths.js";
+
+export async function appendOutreach(
+  home: string,
+  slug: string,
+  entry: OutreachEntry,
+): Promise<void> {
+  const path = outreachFile(home, slug);
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${JSON.stringify(entry)}\n`);
+}
+
+/**
+ * Read the last N outreach entries, oldest-first within the returned slice.
+ * Returns [] if the file does not exist. Malformed lines are skipped silently.
+ */
+export async function readRecentOutreach(
+  home: string,
+  slug: string,
+  limit: number,
+): Promise<OutreachEntry[]> {
+  const path = outreachFile(home, slug);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const lines = raw.split("\n").filter((l) => l.length > 0);
+  const start = Math.max(0, lines.length - limit);
+  const slice = lines.slice(start);
+
+  const result: OutreachEntry[] = [];
+  for (const line of slice) {
+    try {
+      const parsed = JSON.parse(line);
+      result.push(OutreachEntrySchema.parse(parsed));
+    } catch {
+      // malformed line — skip
+    }
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/outreach/audit.test.ts
+```
+
+Expected: PASS — 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/outreach/audit.ts server-ts/src/outreach/audit.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add outreach.jsonl audit appender
+
+Append-only per-instance log. Read helper returns the last N entries;
+malformed lines are silently skipped so a bad write never corrupts reads.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Settings.toml reader
+
+**Files:**
+- Create: `server-ts/src/settings/reader.ts`
+- Create: `server-ts/src/settings/reader.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/settings/reader.test.ts`:
+
+```typescript
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS, loadSettings } from "./reader.js";
+
+describe("loadSettings", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-settings-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns DEFAULT_SETTINGS when settings.toml is missing", async () => {
+    const s = await loadSettings(home, "alice");
+    expect(s).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("merges user-provided fields over defaults", async () => {
+    const dir = join(home, "instances", "alice");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "settings.toml"),
+      `daily_budget_usd = 5.0
+
+[quiet_hours]
+start = "23:00"
+end = "08:00"
+
+[push]
+daily_max = 10
+`,
+    );
+    const s = await loadSettings(home, "alice");
+    expect(s.daily_budget_usd).toBe(5.0);
+    expect(s.quiet_hours.start).toBe("23:00");
+    expect(s.quiet_hours.end).toBe("08:00");
+    expect(s.push.daily_max).toBe(10);
+    // Defaults preserved for unspecified fields
+    expect(s.push.enabled).toBe(true);
+    expect(s.email.enabled).toBe(DEFAULT_SETTINGS.email.enabled);
+  });
+
+  it("DEFAULT_SETTINGS has a 2.00 daily budget", () => {
+    expect(DEFAULT_SETTINGS.daily_budget_usd).toBe(2.0);
+  });
+
+  it("DEFAULT_SETTINGS has 22:00-07:00 quiet hours", () => {
+    expect(DEFAULT_SETTINGS.quiet_hours.start).toBe("22:00");
+    expect(DEFAULT_SETTINGS.quiet_hours.end).toBe("07:00");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/settings/reader.test.ts
+```
+
+Expected: FAIL. Module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `server-ts/src/settings/reader.ts`:
+
+```typescript
+import { z } from "zod";
+import { settingsFile } from "../paths.js";
+import { readToml } from "../toml-file.js";
+
+const SettingsSchema = z.object({
+  daily_budget_usd: z.number().positive().default(2.0),
+  quiet_hours: z
+    .object({
+      start: z.string().default("22:00"),
+      end: z.string().default("07:00"),
+    })
+    .default({}),
+  push: z
+    .object({
+      enabled: z.boolean().default(true),
+      daily_max: z.number().int().positive().default(5),
+    })
+    .default({}),
+  email: z
+    .object({
+      enabled: z.boolean().default(true),
+      address: z.string().optional(),
+      daily_max: z.number().int().positive().default(2),
+    })
+    .default({}),
+});
+
+export type Settings = z.infer<typeof SettingsSchema>;
+
+export const DEFAULT_SETTINGS: Settings = SettingsSchema.parse({});
+
+/**
+ * Read the instance's settings.toml; fall back to DEFAULT_SETTINGS if
+ * the file does not exist. User-provided fields are merged over defaults
+ * by zod's schema default propagation.
+ */
+export async function loadSettings(home: string, slug: string): Promise<Settings> {
+  const result = await readToml(settingsFile(home, slug), SettingsSchema);
+  return result ?? DEFAULT_SETTINGS;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/settings/reader.test.ts
+```
+
+Expected: PASS — 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/settings/reader.ts server-ts/src/settings/reader.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add settings.toml reader with defaults
+
+$2 daily budget, 22:00-07:00 quiet hours, push + email enabled by default.
+User-provided fields merge over defaults via zod schema propagation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Public API re-exports
+
+**Files:**
+- Modify: `server-ts/src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server-ts/src/index.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import * as api from "./index.js";
+
+describe("public API", () => {
+  it("re-exports the foundational modules", () => {
+    expect(api.atomicWrite).toBeTypeOf("function");
+    expect(api.readJson).toBeTypeOf("function");
+    expect(api.writeJson).toBeTypeOf("function");
+    expect(api.readToml).toBeTypeOf("function");
+    expect(api.parseSkill).toBeTypeOf("function");
+    expect(api.loadSkills).toBeTypeOf("function");
+    expect(api.loadTriageRules).toBeTypeOf("function");
+    expect(api.buildTriagePrompt).toBeTypeOf("function");
+    expect(api.loadSettings).toBeTypeOf("function");
+    expect(api.appendOutreach).toBeTypeOf("function");
+    expect(api.readRecentOutreach).toBeTypeOf("function");
+    expect(api.computeState).toBeTypeOf("function");
+    expect(api.loadDaily).toBeTypeOf("function");
+    expect(api.recordSpend).toBeTypeOf("function");
+    expect(api.chargeAndCall).toBeTypeOf("function");
+    expect(api.Throttle).toBeTypeOf("function");
+    expect(api.todayUtc).toBeTypeOf("function");
+  });
+
+  it("re-exports path helpers", () => {
+    expect(api.instanceDir).toBeTypeOf("function");
+    expect(api.conversationFile).toBeTypeOf("function");
+  });
+
+  it("exposes DEFAULT_SETTINGS and DEFAULT_TRIAGE_TEMPLATE", () => {
+    expect(api.DEFAULT_SETTINGS).toBeDefined();
+    expect(api.DEFAULT_TRIAGE_TEMPLATE).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test src/index.test.ts
+```
+
+Expected: FAIL — exports missing on api.
+
+- [ ] **Step 3: Update index.ts**
+
+Replace `server-ts/src/index.ts`:
+
+```typescript
+export const VERSION = "1.0.0-alpha.0";
+
+export * from "./types.js";
+export * from "./paths.js";
+export { atomicWrite } from "./fs-atomic.js";
+export { readJson, writeJson } from "./json-file.js";
+export { readToml } from "./toml-file.js";
+
+export { parseSkill } from "./skills/parse.js";
+export { loadSkills, type LoadSkillsOptions } from "./skills/loader.js";
+
+export { loadTriageRules, DEFAULT_TRIAGE_TEMPLATE } from "./triage/rules.js";
+export {
+  buildTriagePrompt,
+  type OutreachHint,
+  type TriagePromptInputs,
+} from "./triage/prompt.js";
+
+export { loadSettings, DEFAULT_SETTINGS, type Settings } from "./settings/reader.js";
+
+export { appendOutreach, readRecentOutreach } from "./outreach/audit.js";
+
+export { computeState, TIGHT_THRESHOLD } from "./budget/state.js";
+export {
+  loadDaily,
+  recordSpend,
+  todayUtc,
+  type SpendDelta,
+} from "./budget/ledger.js";
+export {
+  chargeAndCall,
+  type ChargeContext,
+  type CallSuccess,
+  type CallDowngraded,
+  type CallOutcome,
+} from "./budget/charge-and-call.js";
+export { Throttle, type ThrottleConfig } from "./budget/throttle.js";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test src/index.test.ts
+```
+
+Expected: PASS — all 3 blocks green.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+pnpm test
+```
+
+Expected: all 17-task tests pass together (approximately 65+ tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/index.ts server-ts/src/index.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): surface foundation modules via public API
+
+index.ts re-exports the stable surface Plan 2 (Mind runtime) will consume:
+types, paths, fs helpers, skills, triage, settings, outreach, budget.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: Typecheck and lint pass
+
+- [ ] **Step 1: Run typecheck across the whole package**
+
+```bash
+cd server-ts && pnpm check
+```
+
+Expected: `tsc --noEmit` passes with no errors, `biome check` reports no problems.
+
+If there are issues: fix them before continuing. Common issues:
+- Missing `type` imports for zod inferred types → add `import type`
+- `exactOptionalPropertyTypes` complaints → explicitly declare `| undefined`
+
+- [ ] **Step 2: Run the full test suite once more**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass (green summary showing the total count).
+
+- [ ] **Step 3: Commit any fixes (if step 1 required changes)**
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+chore(server-ts): typecheck and lint cleanup
+
+Final pass after all foundation modules land.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If no fixes were needed: skip this commit.
+
+- [ ] **Step 4: Tag the foundations milestone**
+
+```bash
+git tag -a foundations-complete -m "Plan 1 complete: server-ts foundation modules"
+```
+
+Do not push the tag yet; the user reviews and pushes in their own cadence.
+
+---
+
+## Self-Review Checklist
+
+Before handing off, the executor should confirm:
+
+- [ ] All 17 task files exist with the specified contents
+- [ ] `pnpm test` reports all green with >60 tests
+- [ ] `pnpm check` has no errors
+- [ ] `git log --oneline` shows one commit per task (17 commits plus optional cleanup)
+- [ ] `server-ts/src/index.ts` exports every foundation module
+- [ ] No TODOs, TBDs, or incomplete sections in any `.ts` file
+
+## What this plan does NOT do (Plan 2 picks it up)
+
+- No Claude Agent SDK integration
+- No HTTP server, no WebSocket
+- No event queue, triage execution, or scheduled jobs
+- No mind runtime / session lifecycle
+- No outreach delivery (push/email/digest) — only the audit log
+- No cross-instance / shared directory
+
+Plan 2 (Mind runtime, weeks 3-5) consumes this surface and produces the first runnable Bolly v1 server.

--- a/docs/superpowers/plans/2026-04-22-mind-runtime.md
+++ b/docs/superpowers/plans/2026-04-22-mind-runtime.md
@@ -1,0 +1,4034 @@
+# Bolly v1 — Mind Runtime Implementation Plan (Plan 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compose Plan 1's foundations into a runnable TypeScript server. One employee sends a user message, the mind loops Claude via Messages API (with custom tools, prompt caching, compaction, streaming), persists the conversation, and streams back `ServerEvent`s over WebSocket. No event queue, no triage, no outreach delivery, no cross-instance — those land in Plans 3–5.
+
+**Architecture:**
+- Hono HTTP server with auth middleware, `POST /api/chat`, and WebSocket at `/api/ws`.
+- One in-process `MindWorker` per active employee (lazy-started, warm for 10 min after last activity).
+- Each worker drives the `runMind` loop: Messages API → handle `tool_use` → execute custom tools inline → loop until `end_turn`. Streaming via `messages.stream()`; compaction via `compact-2026-01-12` beta header; prompt caching via top-level `cache_control`.
+- Conversation persists to `instances/{slug}/chats/{chat_id}/conversation.json` (atomic writes).
+- `ServerEvent` wire format is byte-compatible with the current Rust backend so the SvelteKit client runs unmodified.
+
+**Tech Stack (added in Plan 2):**
+- `@anthropic-ai/sdk` ^0.40.0 (Anthropic Messages API client with `.messages.create`, `.messages.stream`, beta support for `compact-2026-01-12`)
+- `hono` ^4.6.0 + `@hono/node-server` ^1.13.0 (HTTP framework + Node adapter)
+- `@hono/node-ws` (WebSocket upgrade)
+
+**Depends on Plan 1 foundations:**
+- `parseSkill`, `loadSkills` — read enabled skills from disk
+- `loadTriageRules` — system prompt context
+- `loadSettings` — per-employee budget / prefs
+- `chargeAndCall`, `loadDaily`, `recordSpend` — budget gate around Anthropic calls
+- `conversationFile`, `instanceDir` — path helpers
+- `readJson`, `writeJson`, `atomicWrite` — persistence
+- `Skill`, `Settings` types
+
+**Scope (what ships):**
+- HTTP server with auth, chat endpoint, WebSocket broadcast
+- MindWorker: lazy-started per employee, warm TTL, graceful shutdown
+- Full Messages API mind loop: text, tool use, compaction, max_tokens continuation, streaming
+- Custom-tool registry (one tool per enabled skill, plus built-in outreach stubs)
+- System prompt assembly from soul.md + mood + rhythm + skills + triage
+- Conversation persistence (load / append / snapshot)
+- Budget integration (every tier-3 Anthropic call goes through `chargeAndCall`)
+- ServerEvent types matching Rust wire format exactly
+- In-memory mock Anthropic client for unit tests
+- One real-SDK integration test (gated by `INTEGRATION=1`)
+
+**Out of scope (later plans):**
+- Event queue, triage gate, scheduled jobs → Plan 3
+- Outreach delivery (push / email / digest) → Plan 4
+- Cross-instance events + shared directory → Plan 5
+- Polish, E2E, cost validation, `docker compose` image → Plan 6
+- Client-side SvelteKit updates (separate, parallel track)
+
+**Commit convention:** One commit per task. Co-Authored-By trailer on every commit. `feat:` / `test:` / `chore:` / `fix:` prefixes.
+
+---
+
+## File Structure
+
+```
+server-ts/
+├── package.json                   MODIFIED: add sdk, hono deps
+└── src/
+    ├── config.ts                  NEW: env loader (API key, home, port)
+    ├── config.test.ts
+    ├── conversation/
+    │   ├── types.ts               NEW: ConversationEntry, ContentBlock
+    │   ├── types.test.ts
+    │   ├── store.ts               NEW: load / append / snapshot
+    │   └── store.test.ts
+    ├── mind/
+    │   ├── system-prompt.ts       NEW: assemble system prompt
+    │   ├── system-prompt.test.ts
+    │   ├── skill-tool.ts          NEW: Skill → Anthropic Tool
+    │   ├── skill-tool.test.ts
+    │   ├── anthropic-client.ts    NEW: real client factory
+    │   ├── mock-client.ts         NEW: in-memory fake
+    │   ├── mock-client.test.ts
+    │   ├── loop.ts                NEW: the mind loop
+    │   ├── loop.test.ts
+    │   ├── worker.ts              NEW: per-employee MindWorker
+    │   ├── worker.test.ts
+    │   └── pool.ts                NEW: worker pool
+    │   └── pool.test.ts
+    ├── events/
+    │   ├── server-event.ts        NEW: ServerEvent union + schemas
+    │   ├── server-event.test.ts
+    │   ├── broadcaster.ts         NEW: WS broadcast channel
+    │   └── broadcaster.test.ts
+    ├── http/
+    │   ├── auth.ts                NEW: bearer-token middleware
+    │   ├── auth.test.ts
+    │   ├── chat.ts                NEW: POST /api/chat
+    │   ├── ws.ts                  NEW: WebSocket endpoint
+    │   └── server.ts              NEW: Hono app
+    ├── main.ts                    NEW: boot + shutdown
+    └── index.ts                   MODIFIED: add new public exports
+```
+
+Expected size after Plan 2: ~1500–2000 LoC in `src/` + ~1500 LoC of tests. Still well inside the 4000-LoC budget.
+
+---
+
+## Task 1: Add SDK + HTTP deps
+
+**Files:**
+- Modify: `server-ts/package.json`
+
+- [ ] **Step 1: Add dependencies**
+
+From `server-ts/`:
+
+```bash
+pnpm add @anthropic-ai/sdk@^0.40.0 hono@^4.6.0 @hono/node-server@^1.13.0 @hono/node-ws@^1.0.0
+```
+
+- [ ] **Step 2: Verify install**
+
+```bash
+pnpm install
+pnpm check
+pnpm test
+```
+
+Expected: install succeeds; `check` passes (new deps don't affect foundation); `test` still reports 82/82 passing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server-ts/package.json server-ts/pnpm-lock.yaml
+git commit -m "$(cat <<'EOF'
+chore(server-ts): add Anthropic SDK + Hono for mind runtime
+
+Adds @anthropic-ai/sdk (Messages API client, compaction beta),
+hono (HTTP framework) and @hono/node-server / @hono/node-ws
+(Node adapter + WebSocket upgrade).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Config loader
+
+**Files:**
+- Create: `server-ts/src/config.ts`
+- Create: `server-ts/src/config.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { loadConfig, type RuntimeConfig } from "./config.js";
+
+describe("loadConfig", () => {
+  it("reads required fields from env", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+    });
+    expect(cfg.anthropicApiKey).toBe("sk-ant-test");
+    expect(cfg.bollyHome).toBe("/tmp/bolly");
+  });
+
+  it("defaults http port to 4242", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+    });
+    expect(cfg.httpPort).toBe(4242);
+  });
+
+  it("reads BOLLY_HTTP_PORT override", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+      BOLLY_HTTP_PORT: "8080",
+    });
+    expect(cfg.httpPort).toBe(8080);
+  });
+
+  it("reads optional BOLLY_AUTH_TOKEN", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+      BOLLY_AUTH_TOKEN: "secret",
+    });
+    expect(cfg.authToken).toBe("secret");
+  });
+
+  it("authToken is undefined when BOLLY_AUTH_TOKEN is unset", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+    });
+    expect(cfg.authToken).toBeUndefined();
+  });
+
+  it("throws when ANTHROPIC_API_KEY is missing", () => {
+    expect(() => loadConfig({ BOLLY_HOME: "/tmp/bolly" })).toThrow(/ANTHROPIC_API_KEY/);
+  });
+
+  it("throws when BOLLY_HOME is missing", () => {
+    expect(() => loadConfig({ ANTHROPIC_API_KEY: "sk-ant-test" })).toThrow(/BOLLY_HOME/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/config.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+export type RuntimeConfig = {
+  anthropicApiKey: string;
+  bollyHome: string;
+  httpPort: number;
+  authToken: string | undefined;
+};
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Load runtime config from a plain env-like object.
+ * Accepts `process.env` at boot; accepts a mock at test time.
+ */
+export function loadConfig(env: Env): RuntimeConfig {
+  const anthropicApiKey = env.ANTHROPIC_API_KEY;
+  if (!anthropicApiKey) throw new Error("ANTHROPIC_API_KEY is required");
+
+  const bollyHome = env.BOLLY_HOME;
+  if (!bollyHome) throw new Error("BOLLY_HOME is required");
+
+  const port = env.BOLLY_HTTP_PORT ? Number(env.BOLLY_HTTP_PORT) : 4242;
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error(`BOLLY_HTTP_PORT is not a valid port: ${env.BOLLY_HTTP_PORT}`);
+  }
+
+  return {
+    anthropicApiKey,
+    bollyHome,
+    httpPort: port,
+    authToken: env.BOLLY_AUTH_TOKEN,
+  };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (7 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/config.ts server-ts/src/config.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add runtime config loader
+
+Reads ANTHROPIC_API_KEY, BOLLY_HOME, optional BOLLY_HTTP_PORT (default 4242)
+and optional BOLLY_AUTH_TOKEN from a plain env object. Accepts process.env
+at boot and a mock at test time.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Conversation entry types
+
+**Files:**
+- Create: `server-ts/src/conversation/types.ts`
+- Create: `server-ts/src/conversation/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import {
+  ContentBlockSchema,
+  ConversationEntrySchema,
+  type ConversationEntry,
+} from "./types.js";
+
+describe("ContentBlockSchema", () => {
+  it("accepts a text block", () => {
+    const parsed = ContentBlockSchema.parse({ type: "text", text: "hi" });
+    expect(parsed).toEqual({ type: "text", text: "hi" });
+  });
+
+  it("accepts a tool_use block", () => {
+    const parsed = ContentBlockSchema.parse({
+      type: "tool_use",
+      id: "toolu_1",
+      name: "send_push",
+      input: { title: "hi" },
+    });
+    expect(parsed.type).toBe("tool_use");
+  });
+
+  it("accepts a tool_result block", () => {
+    const parsed = ContentBlockSchema.parse({
+      type: "tool_result",
+      tool_use_id: "toolu_1",
+      content: "done",
+    });
+    expect(parsed.type).toBe("tool_result");
+  });
+
+  it("rejects unknown block types", () => {
+    expect(() => ContentBlockSchema.parse({ type: "wut", x: 1 })).toThrow();
+  });
+});
+
+describe("ConversationEntrySchema", () => {
+  it("parses a minimal user entry", () => {
+    const entry = {
+      id: "msg_1",
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "hello" }],
+      ts: 1714000000000,
+    };
+    const parsed: ConversationEntry = ConversationEntrySchema.parse(entry);
+    expect(parsed.role).toBe("user");
+  });
+
+  it("parses an assistant entry with model field", () => {
+    const entry = {
+      id: "msg_2",
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: "hi back" }],
+      ts: 1714000001000,
+      model: "claude-sonnet-4-6",
+    };
+    const parsed = ConversationEntrySchema.parse(entry);
+    expect(parsed.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("rejects entries with invalid role", () => {
+    expect(() =>
+      ConversationEntrySchema.parse({
+        id: "msg_3",
+        role: "system",
+        content: [],
+        ts: 0,
+      }),
+    ).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/conversation/types.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import { z } from "zod";
+
+export const TextBlockSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+
+export const ToolUseBlockSchema = z.object({
+  type: z.literal("tool_use"),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  input: z.record(z.unknown()),
+});
+
+export const ToolResultBlockSchema = z.object({
+  type: z.literal("tool_result"),
+  tool_use_id: z.string().min(1),
+  content: z.string(),
+  is_error: z.boolean().optional(),
+});
+
+export const CompactionBlockSchema = z.object({
+  type: z.literal("compaction"),
+  content: z.string(),
+});
+
+export const ContentBlockSchema = z.discriminatedUnion("type", [
+  TextBlockSchema,
+  ToolUseBlockSchema,
+  ToolResultBlockSchema,
+  CompactionBlockSchema,
+]);
+export type ContentBlock = z.infer<typeof ContentBlockSchema>;
+
+export const ConversationRoleSchema = z.enum(["user", "assistant"]);
+export type ConversationRole = z.infer<typeof ConversationRoleSchema>;
+
+export const ConversationEntrySchema = z.object({
+  id: z.string().min(1),
+  role: ConversationRoleSchema,
+  content: z.array(ContentBlockSchema),
+  ts: z.number().int().nonnegative(),
+  model: z.string().optional(),
+});
+export type ConversationEntry = z.infer<typeof ConversationEntrySchema>;
+
+export const ConversationSchema = z.array(ConversationEntrySchema);
+export type Conversation = z.infer<typeof ConversationSchema>;
+```
+
+- [ ] **Step 4: Run test, verify PASS (7 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/conversation/types.ts server-ts/src/conversation/types.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add conversation entry schema
+
+Discriminated union on content block: text, tool_use, tool_result, compaction.
+Each ConversationEntry has id, role, content blocks, timestamp, and optional
+model name (assistant turns only).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Conversation store
+
+**Files:**
+- Create: `server-ts/src/conversation/store.ts`
+- Create: `server-ts/src/conversation/store.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendConversationEntry,
+  loadConversation,
+  saveConversation,
+} from "./store.js";
+import type { ConversationEntry } from "./types.js";
+
+function entry(id: string, ts: number): ConversationEntry {
+  return {
+    id,
+    role: "user",
+    content: [{ type: "text", text: `hello ${id}` }],
+    ts,
+  };
+}
+
+describe("conversation store", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-conv-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("loadConversation returns empty array when file is missing", async () => {
+    const result = await loadConversation(home, "alice", "default");
+    expect(result).toEqual([]);
+  });
+
+  it("saveConversation then loadConversation round-trips", async () => {
+    await saveConversation(home, "alice", "default", [entry("a", 100), entry("b", 200)]);
+    const result = await loadConversation(home, "alice", "default");
+    expect(result.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("appendConversationEntry writes a new entry to a fresh file", async () => {
+    await appendConversationEntry(home, "alice", "default", entry("a", 100));
+    const result = await loadConversation(home, "alice", "default");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("a");
+  });
+
+  it("appendConversationEntry appends to an existing file", async () => {
+    await appendConversationEntry(home, "alice", "default", entry("a", 100));
+    await appendConversationEntry(home, "alice", "default", entry("b", 200));
+    const result = await loadConversation(home, "alice", "default");
+    expect(result.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("saveConversation writes atomically (no .tmp residue)", async () => {
+    await saveConversation(home, "alice", "default", [entry("a", 100)]);
+    const { readdir } = await import("node:fs/promises");
+    const dir = join(home, "instances", "alice", "chats", "default");
+    const entries = await readdir(dir);
+    expect(entries).toEqual(["conversation.json"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/conversation/store.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import { readJson, writeJson } from "../json-file.js";
+import { conversationFile } from "../paths.js";
+import {
+  type Conversation,
+  ConversationSchema,
+  type ConversationEntry,
+} from "./types.js";
+
+export async function loadConversation(
+  home: string,
+  slug: string,
+  chatId: string,
+): Promise<Conversation> {
+  const path = conversationFile(home, slug, chatId);
+  const existing = await readJson(path, ConversationSchema);
+  return (existing ?? []) as Conversation;
+}
+
+export async function saveConversation(
+  home: string,
+  slug: string,
+  chatId: string,
+  conversation: Conversation,
+): Promise<void> {
+  await writeJson(conversationFile(home, slug, chatId), conversation);
+}
+
+export async function appendConversationEntry(
+  home: string,
+  slug: string,
+  chatId: string,
+  entry: ConversationEntry,
+): Promise<void> {
+  const existing = await loadConversation(home, slug, chatId);
+  existing.push(entry);
+  await saveConversation(home, slug, chatId, existing);
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (5 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/conversation/store.ts server-ts/src/conversation/store.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add conversation store
+
+load / save / append helpers backed by conversation.json.
+All writes go through the atomic json-file helper.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: System prompt assembler
+
+**Files:**
+- Create: `server-ts/src/mind/system-prompt.ts`
+- Create: `server-ts/src/mind/system-prompt.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../types.js";
+import { buildSystemPrompt } from "./system-prompt.js";
+
+const SKILL: Skill = {
+  frontmatter: {
+    name: "email-check",
+    triggers: [{ scheduled: "every weekday at 8am" }],
+    tools: [],
+    enabled: true,
+  },
+  body: "When triggered, read unread emails and surface urgent items.",
+  path: "/skills/email-check.md",
+};
+
+describe("buildSystemPrompt", () => {
+  it("includes employee name and company name", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "I am calm and attentive.",
+      mood: "focused",
+      rhythm: "morning person",
+      enabledSkills: [],
+      triageRules: "",
+    });
+    expect(prompt).toContain("alice");
+    expect(prompt).toContain("Acme");
+  });
+
+  it("embeds soul / mood / rhythm", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "MY_SOUL",
+      mood: "MY_MOOD",
+      rhythm: "MY_RHYTHM",
+      enabledSkills: [],
+      triageRules: "",
+    });
+    expect(prompt).toContain("MY_SOUL");
+    expect(prompt).toContain("MY_MOOD");
+    expect(prompt).toContain("MY_RHYTHM");
+  });
+
+  it("lists each enabled skill by name and tool", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "",
+      mood: "",
+      rhythm: "",
+      enabledSkills: [SKILL],
+      triageRules: "",
+    });
+    expect(prompt).toContain("email-check");
+    expect(prompt).toContain("run_email_check");
+  });
+
+  it("skips a skills block entirely when no skills are enabled", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "",
+      mood: "",
+      rhythm: "",
+      enabledSkills: [],
+      triageRules: "",
+    });
+    expect(prompt).not.toContain("<skills>");
+  });
+
+  it("includes triage rules when present", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "",
+      mood: "",
+      rhythm: "",
+      enabledSkills: [],
+      triageRules: "ALWAYS escalate urgent email",
+    });
+    expect(prompt).toContain("ALWAYS escalate urgent email");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/system-prompt.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import type { Skill } from "../types.js";
+import { skillToToolName } from "./skill-tool.js";
+
+export type SystemPromptInputs = {
+  employeeName: string;
+  companyName: string;
+  soul: string;
+  mood: string;
+  rhythm: string;
+  enabledSkills: Skill[];
+  triageRules: string;
+};
+
+/**
+ * Build the system prompt for the mind. Output is stable for the same inputs,
+ * so it caches well via cache_control.
+ */
+export function buildSystemPrompt(inputs: SystemPromptInputs): string {
+  const {
+    employeeName,
+    companyName,
+    soul,
+    mood,
+    rhythm,
+    enabledSkills,
+    triageRules,
+  } = inputs;
+
+  const skillsBlock =
+    enabledSkills.length === 0
+      ? ""
+      : `
+
+<skills>
+${enabledSkills
+  .map((s) => {
+    const tool = skillToToolName(s.frontmatter.name);
+    return `- ${s.frontmatter.name} (tool: ${tool})\n  ${s.body.trim()}`;
+  })
+  .join("\n\n")}
+</skills>`;
+
+  const triageBlock = triageRules.trim()
+    ? `
+
+<triage_rules>
+${triageRules.trim()}
+</triage_rules>`
+    : "";
+
+  return `You are Bolly, the AI coworker for ${employeeName} at ${companyName}.
+
+<persona>${soul}</persona>
+<mood>${mood}</mood>
+<rhythm>${rhythm}</rhythm>${skillsBlock}${triageBlock}
+
+Use the custom tools available to you when appropriate. You may reach out
+to ${employeeName} via send_push, send_email, or defer_for_digest.`;
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (5 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/system-prompt.ts server-ts/src/mind/system-prompt.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add system prompt assembler
+
+Composes soul + mood + rhythm + enabled skills + triage rules into a
+cache-stable system prompt string. One skill → one custom tool name.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Skill → tool mapping
+
+**Files:**
+- Create: `server-ts/src/mind/skill-tool.ts`
+- Create: `server-ts/src/mind/skill-tool.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../types.js";
+import { builtInTools, skillToTool, skillToToolName } from "./skill-tool.js";
+
+const SKILL: Skill = {
+  frontmatter: {
+    name: "email-morning-check",
+    triggers: [],
+    tools: [],
+    enabled: true,
+  },
+  body: "Read unread email and summarize urgent items.",
+  path: "/skills/x.md",
+};
+
+describe("skillToToolName", () => {
+  it("prefixes with run_ and replaces dashes with underscores", () => {
+    expect(skillToToolName("email-morning-check")).toBe("run_email_morning_check");
+  });
+
+  it("preserves underscores", () => {
+    expect(skillToToolName("simple_name")).toBe("run_simple_name");
+  });
+});
+
+describe("skillToTool", () => {
+  it("produces a tool definition with the right name and description", () => {
+    const tool = skillToTool(SKILL);
+    expect(tool.name).toBe("run_email_morning_check");
+    expect(tool.description).toContain("Read unread email");
+  });
+
+  it("accepts an input schema with a free-form context argument", () => {
+    const tool = skillToTool(SKILL);
+    expect(tool.input_schema.type).toBe("object");
+    expect(tool.input_schema.properties).toHaveProperty("context");
+  });
+});
+
+describe("builtInTools", () => {
+  it("provides send_push, send_email, defer_for_digest", () => {
+    const names = builtInTools().map((t) => t.name);
+    expect(names).toContain("send_push");
+    expect(names).toContain("send_email");
+    expect(names).toContain("defer_for_digest");
+  });
+
+  it("send_push has a title and body schema", () => {
+    const push = builtInTools().find((t) => t.name === "send_push");
+    expect(push?.input_schema.required).toContain("title");
+    expect(push?.input_schema.required).toContain("body");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/skill-tool.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import type { Skill } from "../types.js";
+
+/**
+ * A JSON-schema object suitable for the Anthropic Messages API `tools` array.
+ */
+export type ToolDefinition = {
+  name: string;
+  description: string;
+  input_schema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+};
+
+export function skillToToolName(skillName: string): string {
+  return `run_${skillName.replace(/-/g, "_")}`;
+}
+
+export function skillToTool(skill: Skill): ToolDefinition {
+  return {
+    name: skillToToolName(skill.frontmatter.name),
+    description: skill.body.trim(),
+    input_schema: {
+      type: "object",
+      properties: {
+        context: {
+          type: "string",
+          description: "Free-form context describing why this skill should run",
+        },
+      },
+      required: [],
+    },
+  };
+}
+
+export function builtInTools(): ToolDefinition[] {
+  return [
+    {
+      name: "send_push",
+      description:
+        "Send a push notification to the employee. Use for time-sensitive, short messages worth interrupting for.",
+      input_schema: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Short title, <100 chars" },
+          body: { type: "string", description: "Body text" },
+          urgency: {
+            type: "string",
+            enum: ["low", "medium", "high"],
+            description: "Interrupt priority",
+          },
+        },
+        required: ["title", "body"],
+      },
+    },
+    {
+      name: "send_email",
+      description:
+        "Send an email to the employee. Use for longer, async messages such as morning briefs or summaries.",
+      input_schema: {
+        type: "object",
+        properties: {
+          subject: { type: "string" },
+          body_markdown: { type: "string" },
+        },
+        required: ["subject", "body_markdown"],
+      },
+    },
+    {
+      name: "defer_for_digest",
+      description:
+        "File a note for the employee's next return to the app. Use for anything not pressing.",
+      input_schema: {
+        type: "object",
+        properties: {
+          summary: { type: "string" },
+        },
+        required: ["summary"],
+      },
+    },
+  ];
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (6 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/skill-tool.ts server-ts/src/mind/skill-tool.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add skill → Anthropic tool mapping
+
+skillToToolName normalizes skill names into run_* tool names.
+skillToTool converts a Skill into a JSON-schema tool definition.
+builtInTools returns the outreach tools (send_push, send_email, defer_for_digest)
+that every employee's mind has access to.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Anthropic client factory
+
+**Files:**
+- Create: `server-ts/src/mind/anthropic-client.ts`
+- Create: `server-ts/src/mind/anthropic-client.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { createAnthropicClient, type MindClient } from "./anthropic-client.js";
+
+describe("createAnthropicClient", () => {
+  it("returns an object with messages.create and messages.stream methods", () => {
+    const client: MindClient = createAnthropicClient("sk-ant-test");
+    expect(typeof client.messages.create).toBe("function");
+    expect(typeof client.messages.stream).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/anthropic-client.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+/**
+ * The subset of the Anthropic SDK surface the mind uses.
+ * The mock client in tests implements this same interface.
+ */
+export type MindClient = {
+  messages: {
+    create: Anthropic["messages"]["create"];
+    stream: Anthropic["messages"]["stream"];
+  };
+};
+
+export function createAnthropicClient(apiKey: string): MindClient {
+  const client = new Anthropic({ apiKey });
+  return {
+    messages: {
+      create: client.messages.create.bind(client.messages),
+      stream: client.messages.stream.bind(client.messages),
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (1 test)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/anthropic-client.ts server-ts/src/mind/anthropic-client.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add Anthropic client factory
+
+Thin factory around @anthropic-ai/sdk that returns only the two surfaces
+the mind uses: messages.create and messages.stream. Exports a MindClient
+type so the mock client in tests stays structurally compatible.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Mock Anthropic client
+
+**Files:**
+- Create: `server-ts/src/mind/mock-client.ts`
+- Create: `server-ts/src/mind/mock-client.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { MockAnthropicClient, type MockMessage } from "./mock-client.js";
+
+const TEXT_MESSAGE: MockMessage = {
+  id: "msg_1",
+  role: "assistant",
+  model: "mock",
+  stop_reason: "end_turn",
+  content: [{ type: "text", text: "hello" }],
+  usage: { input_tokens: 100, output_tokens: 20 },
+};
+
+const TOOL_USE_MESSAGE: MockMessage = {
+  id: "msg_2",
+  role: "assistant",
+  model: "mock",
+  stop_reason: "tool_use",
+  content: [
+    {
+      type: "tool_use",
+      id: "toolu_1",
+      name: "send_push",
+      input: { title: "hi", body: "there" },
+    },
+  ],
+  usage: { input_tokens: 120, output_tokens: 30 },
+};
+
+describe("MockAnthropicClient.messages.create", () => {
+  it("returns queued messages in FIFO order", async () => {
+    const client = new MockAnthropicClient([TEXT_MESSAGE]);
+    const m = await client.messages.create({
+      model: "mock",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(m.content[0]).toEqual({ type: "text", text: "hello" });
+  });
+
+  it("records each call so tests can assert on the request shape", async () => {
+    const client = new MockAnthropicClient([TEXT_MESSAGE]);
+    await client.messages.create({
+      model: "mock",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]?.messages[0]?.content).toBe("hi");
+  });
+
+  it("throws when queue is empty", async () => {
+    const client = new MockAnthropicClient([]);
+    await expect(
+      client.messages.create({
+        model: "mock",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    ).rejects.toThrow(/no queued response/i);
+  });
+
+  it("supports a tool_use stop reason", async () => {
+    const client = new MockAnthropicClient([TOOL_USE_MESSAGE]);
+    const m = await client.messages.create({
+      model: "mock",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "push me" }],
+    });
+    expect(m.stop_reason).toBe("tool_use");
+    expect(m.content[0]).toMatchObject({ type: "tool_use", name: "send_push" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/mock-client.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import type Anthropic from "@anthropic-ai/sdk";
+import type { MindClient } from "./anthropic-client.js";
+
+export type MockMessage = {
+  id: string;
+  role: "assistant";
+  model: string;
+  stop_reason:
+    | "end_turn"
+    | "tool_use"
+    | "max_tokens"
+    | "stop_sequence"
+    | "pause_turn"
+    | "refusal";
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+    | { type: "compaction"; content: string }
+  >;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+};
+
+type CreateParams = Anthropic.Messages.MessageCreateParamsNonStreaming;
+
+/**
+ * In-memory Anthropic client that replays a queue of canned messages.
+ * Records every call for later assertion. Implements the same shape as
+ * MindClient so the loop can accept either one.
+ */
+export class MockAnthropicClient implements MindClient {
+  readonly calls: CreateParams[] = [];
+  private readonly queue: MockMessage[];
+
+  constructor(responses: MockMessage[]) {
+    this.queue = [...responses];
+  }
+
+  readonly messages = {
+    create: async (params: CreateParams): Promise<MockMessage> => {
+      this.calls.push(params);
+      const next = this.queue.shift();
+      if (!next) throw new Error("MockAnthropicClient: no queued response");
+      return next;
+    },
+    // Streaming mock ships in a later task; create alone covers Tasks 10–13.
+    stream: (): never => {
+      throw new Error("MockAnthropicClient.stream: not implemented in this fixture");
+    },
+  } as unknown as MindClient["messages"];
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (4 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+If the `as unknown as MindClient["messages"]` triggers a biome rule, accept it — this is the minimum cast to let the mock fake the SDK surface. The real SDK types are deeply nested, and re-typing them in the mock would be high-maintenance.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/mock-client.ts server-ts/src/mind/mock-client.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add in-memory mock Anthropic client
+
+Replays a queue of canned MockMessage responses; records each call for
+assertions. Covers messages.create only; streaming mock added in Task 14.
+Implements MindClient so tests can swap it in without adapters.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Mind loop — single-turn text response
+
+**Files:**
+- Create: `server-ts/src/mind/loop.ts`
+- Create: `server-ts/src/mind/loop.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { MockAnthropicClient } from "./mock-client.js";
+import { runMindTurn } from "./loop.js";
+
+describe("runMindTurn — single-turn text", () => {
+  it("sends a user message and returns the assistant text", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "hi there" }],
+        usage: { input_tokens: 100, output_tokens: 20 },
+      },
+    ]);
+
+    const result = await runMindTurn({
+      client,
+      model: "claude-sonnet-4-6",
+      systemPrompt: "You are Bolly.",
+      tools: [],
+      conversation: [],
+      userMessage: "hello",
+    });
+
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.assistantContent).toEqual([{ type: "text", text: "hi there" }]);
+    expect(result.totalUsage.input_tokens).toBe(100);
+    expect(result.totalUsage.output_tokens).toBe(20);
+  });
+
+  it("passes the full message array including the new user message", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 50, output_tokens: 5 },
+      },
+    ]);
+
+    await runMindTurn({
+      client,
+      model: "claude-sonnet-4-6",
+      systemPrompt: "You are Bolly.",
+      tools: [],
+      conversation: [
+        { id: "p1", role: "user", content: [{ type: "text", text: "prior" }], ts: 1 },
+      ],
+      userMessage: "hello",
+    });
+
+    const call = client.calls[0];
+    expect(call?.messages).toHaveLength(2);
+    expect(call?.messages[0]?.content).toEqual([{ type: "text", text: "prior" }]);
+    expect(call?.messages[1]?.content).toBe("hello");
+  });
+
+  it("includes the system prompt on the request", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+
+    await runMindTurn({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+    });
+
+    expect(client.calls[0]?.system).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/loop.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import type Anthropic from "@anthropic-ai/sdk";
+import type { MindClient } from "./anthropic-client.js";
+import type { ContentBlock, ConversationEntry } from "../conversation/types.js";
+import type { ToolDefinition } from "./skill-tool.js";
+
+export type MindTurnInputs = {
+  client: MindClient;
+  model: string;
+  systemPrompt: string;
+  tools: ToolDefinition[];
+  conversation: ConversationEntry[];
+  userMessage: string;
+};
+
+export type MindTurnResult = {
+  stopReason: string;
+  assistantContent: ContentBlock[];
+  totalUsage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens: number;
+  };
+};
+
+/**
+ * Convert a Conversation into the Anthropic messages array shape.
+ * Each entry becomes one role-tagged message; content blocks pass through.
+ */
+function conversationToMessages(
+  conversation: ConversationEntry[],
+): Anthropic.Messages.MessageParam[] {
+  return conversation.map((e) => ({
+    role: e.role,
+    content: e.content as unknown as Anthropic.Messages.ContentBlockParam[],
+  }));
+}
+
+/**
+ * Run a single mind turn without tool use or continuation.
+ * Higher-level wrappers compose multiple turns for tool use etc.
+ */
+export async function runMindTurn(inputs: MindTurnInputs): Promise<MindTurnResult> {
+  const { client, model, systemPrompt, tools, conversation, userMessage } = inputs;
+
+  const messages: Anthropic.Messages.MessageParam[] = [
+    ...conversationToMessages(conversation),
+    { role: "user", content: userMessage },
+  ];
+
+  const response = await client.messages.create({
+    model,
+    max_tokens: 4096,
+    system: systemPrompt,
+    tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+    messages,
+  });
+
+  return {
+    stopReason: response.stop_reason ?? "end_turn",
+    assistantContent: response.content as unknown as ContentBlock[],
+    totalUsage: {
+      input_tokens: response.usage.input_tokens,
+      output_tokens: response.usage.output_tokens,
+      cache_read_input_tokens: response.usage.cache_read_input_tokens ?? 0,
+      cache_creation_input_tokens: response.usage.cache_creation_input_tokens ?? 0,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (3 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/loop.ts server-ts/src/mind/loop.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add single-turn mind loop
+
+runMindTurn converts conversation history + a new user message into an
+Anthropic messages.create request, returns the assistant content and
+aggregated token usage. Later tasks extend this with tool_use handling,
+max_tokens continuation, caching, compaction, and streaming.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Mind loop — tool-use handling
+
+**Files:**
+- Modify: `server-ts/src/mind/loop.ts`
+- Modify: `server-ts/src/mind/loop.test.ts`
+
+- [ ] **Step 1: Extend the test**
+
+Append to `server-ts/src/mind/loop.test.ts`:
+
+```typescript
+import { runMindWithTools } from "./loop.js";
+
+describe("runMindWithTools — tool-use loop", () => {
+  it("executes a tool call and continues to end_turn", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_a",
+            name: "send_push",
+            input: { title: "Q2 review", body: "urgent" },
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 10 },
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "sent" }],
+        usage: { input_tokens: 120, output_tokens: 5 },
+      },
+    ]);
+
+    const toolCalls: Array<{ name: string; input: unknown }> = [];
+    const result = await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "push me",
+      executeTool: async (name, input) => {
+        toolCalls.push({ name, input });
+        return "ok";
+      },
+      maxIterations: 5,
+    });
+
+    expect(toolCalls).toEqual([
+      { name: "send_push", input: { title: "Q2 review", body: "urgent" } },
+    ]);
+    expect(result.finalText).toBe("sent");
+    expect(result.turns).toBe(2);
+    expect(result.totalUsage.input_tokens).toBe(220);
+    expect(result.totalUsage.output_tokens).toBe(15);
+  });
+
+  it("stops with an error if an unknown tool is called", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_b",
+            name: "does_not_exist",
+            input: {},
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 10 },
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "caught error" }],
+        usage: { input_tokens: 120, output_tokens: 5 },
+      },
+    ]);
+
+    const result = await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "do it",
+      executeTool: async (name) => {
+        throw new Error(`unknown tool: ${name}`);
+      },
+      maxIterations: 5,
+    });
+
+    expect(result.finalText).toBe("caught error");
+    // Second call should have the is_error tool_result
+    const secondCall = client.calls[1];
+    const toolResult = secondCall?.messages[secondCall.messages.length - 1];
+    expect(toolResult?.role).toBe("user");
+    const firstBlock = (toolResult?.content as Array<{ type: string; is_error?: boolean }>)[0];
+    expect(firstBlock?.type).toBe("tool_result");
+    expect(firstBlock?.is_error).toBe(true);
+  });
+
+  it("stops at maxIterations", async () => {
+    const toolUseMsg = {
+      id: "msg_loop",
+      role: "assistant" as const,
+      model: "mock",
+      stop_reason: "tool_use" as const,
+      content: [
+        {
+          type: "tool_use" as const,
+          id: "toolu_x",
+          name: "send_push",
+          input: { title: "x", body: "y" },
+        },
+      ],
+      usage: { input_tokens: 10, output_tokens: 2 },
+    };
+    const client = new MockAnthropicClient([toolUseMsg, toolUseMsg, toolUseMsg]);
+
+    const result = await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "push me",
+      executeTool: async () => "ok",
+      maxIterations: 2,
+    });
+
+    expect(result.turns).toBe(2);
+    expect(result.hitMaxIterations).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/loop.test.ts
+```
+
+- [ ] **Step 3: Extend the implementation**
+
+Append to `server-ts/src/mind/loop.ts`:
+
+```typescript
+export type MindFullTurnInputs = MindTurnInputs & {
+  executeTool: (name: string, input: Record<string, unknown>) => Promise<string>;
+  maxIterations: number;
+};
+
+export type MindFullTurnResult = {
+  finalText: string;
+  turns: number;
+  hitMaxIterations: boolean;
+  assistantContent: ContentBlock[];
+  totalUsage: MindTurnResult["totalUsage"];
+};
+
+/**
+ * Run the mind in a loop until Claude stops calling tools or maxIterations
+ * is reached. Each tool_use block is executed via the supplied executeTool
+ * callback; errors become is_error: true tool_result blocks rather than
+ * throwing, so Claude can observe and recover.
+ */
+export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<MindFullTurnResult> {
+  const { client, model, systemPrompt, tools, executeTool, maxIterations } = inputs;
+
+  let messages: Anthropic.Messages.MessageParam[] = [
+    ...conversationToMessages(inputs.conversation),
+    { role: "user", content: inputs.userMessage },
+  ];
+
+  let totalInput = 0;
+  let totalOutput = 0;
+  let totalCacheRead = 0;
+  let totalCacheCreation = 0;
+
+  let lastAssistantContent: ContentBlock[] = [];
+  let turns = 0;
+
+  for (let i = 0; i < maxIterations; i++) {
+    turns++;
+    const response = await client.messages.create({
+      model,
+      max_tokens: 4096,
+      system: systemPrompt,
+      tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+      messages,
+    });
+
+    totalInput += response.usage.input_tokens;
+    totalOutput += response.usage.output_tokens;
+    totalCacheRead += response.usage.cache_read_input_tokens ?? 0;
+    totalCacheCreation += response.usage.cache_creation_input_tokens ?? 0;
+
+    lastAssistantContent = response.content as unknown as ContentBlock[];
+
+    // Append assistant turn to the running history
+    messages = [
+      ...messages,
+      { role: "assistant", content: response.content as unknown as Anthropic.Messages.ContentBlockParam[] },
+    ];
+
+    if (response.stop_reason !== "tool_use") break;
+
+    // Execute each tool_use block and produce tool_result blocks
+    const toolResultBlocks: Anthropic.Messages.ContentBlockParam[] = [];
+    for (const block of response.content) {
+      if (block.type !== "tool_use") continue;
+      let content: string;
+      let isError = false;
+      try {
+        content = await executeTool(block.name, block.input as Record<string, unknown>);
+      } catch (err) {
+        content = `error: ${(err as Error).message}`;
+        isError = true;
+      }
+      toolResultBlocks.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content,
+        is_error: isError,
+      });
+    }
+
+    messages = [...messages, { role: "user", content: toolResultBlocks }];
+  }
+
+  const finalText = lastAssistantContent
+    .filter((b) => b.type === "text")
+    .map((b) => (b as { type: "text"; text: string }).text)
+    .join("");
+
+  return {
+    finalText,
+    turns,
+    hitMaxIterations: turns >= maxIterations,
+    assistantContent: lastAssistantContent,
+    totalUsage: {
+      input_tokens: totalInput,
+      output_tokens: totalOutput,
+      cache_read_input_tokens: totalCacheRead,
+      cache_creation_input_tokens: totalCacheCreation,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (all test blocks pass including the 3 new ones)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/loop.ts server-ts/src/mind/loop.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add tool-use loop to the mind
+
+runMindWithTools iterates the Messages API, executing custom tool_use
+blocks via a supplied callback. Tool errors become is_error: true
+tool_result blocks rather than exceptions, so the model can observe
+and recover. Bounded by maxIterations.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Mind loop — max_tokens continuation + prompt caching
+
+**Files:**
+- Modify: `server-ts/src/mind/loop.ts`
+- Modify: `server-ts/src/mind/loop.test.ts`
+
+- [ ] **Step 1: Extend the test**
+
+Append to `server-ts/src/mind/loop.test.ts`:
+
+```typescript
+describe("runMindWithTools — max_tokens continuation", () => {
+  it("re-prompts on stop_reason: max_tokens and merges output", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "max_tokens",
+        content: [{ type: "text", text: "part one" }],
+        usage: { input_tokens: 100, output_tokens: 4096 },
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "part two" }],
+        usage: { input_tokens: 200, output_tokens: 100 },
+      },
+    ]);
+
+    const result = await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "write a long thing",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    expect(result.finalText).toBe("part two");
+    expect(result.turns).toBe(2);
+    // Second call should include a continuation nudge as the last user message
+    const secondCall = client.calls[1];
+    const lastMsg = secondCall?.messages[secondCall.messages.length - 1];
+    expect(lastMsg?.role).toBe("user");
+    expect(JSON.stringify(lastMsg?.content)).toMatch(/continue/i);
+  });
+});
+
+describe("runMindWithTools — prompt caching", () => {
+  it("passes top-level cache_control: ephemeral by default", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+
+    await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    const call = client.calls[0] as unknown as { cache_control?: { type: string } };
+    expect(call.cache_control).toEqual({ type: "ephemeral" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/loop.test.ts
+```
+
+- [ ] **Step 3: Extend the implementation**
+
+In `server-ts/src/mind/loop.ts`, replace the body of `runMindWithTools`'s `for` loop with one that handles `max_tokens` and that passes `cache_control` on every call. Also add the continuation constant.
+
+Find:
+```typescript
+    if (response.stop_reason !== "tool_use") break;
+```
+Replace with:
+```typescript
+    if (response.stop_reason === "max_tokens") {
+      messages = [
+        ...messages,
+        { role: "user", content: CONTINUATION_PROMPT },
+      ];
+      continue;
+    }
+    if (response.stop_reason !== "tool_use") break;
+```
+
+Find:
+```typescript
+    const response = await client.messages.create({
+      model,
+      max_tokens: 4096,
+      system: systemPrompt,
+      tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+      messages,
+    });
+```
+Replace with:
+```typescript
+    const response = await client.messages.create({
+      model,
+      max_tokens: 4096,
+      system: systemPrompt,
+      tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+      messages,
+      // biome-ignore lint/suspicious/noExplicitAny: top-level cache_control is not in the typed params yet
+      cache_control: { type: "ephemeral" },
+    } as any);
+```
+
+At the top of the file, below `import type { ToolDefinition }`, add:
+```typescript
+const CONTINUATION_PROMPT =
+  "[system: your previous response was cut off due to length. please continue exactly where you left off.]";
+```
+
+- [ ] **Step 4: Run test, verify PASS**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/loop.ts server-ts/src/mind/loop.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): handle max_tokens continuation and prompt caching
+
+max_tokens: inject continuation user message and re-prompt.
+Top-level cache_control: ephemeral on every request so stable system +
+early-conversation prefix caches at ~5-min TTL.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Mind loop — server-side compaction
+
+**Files:**
+- Modify: `server-ts/src/mind/loop.ts`
+- Modify: `server-ts/src/mind/loop.test.ts`
+
+- [ ] **Step 1: Extend the test**
+
+Append to `server-ts/src/mind/loop.test.ts`:
+
+```typescript
+describe("runMindWithTools — compaction", () => {
+  it("passes context_management and the compact beta header", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+
+    await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    const call = client.calls[0] as unknown as {
+      context_management?: { edits: Array<{ type: string }> };
+      betas?: string[];
+    };
+    expect(call.context_management?.edits?.[0]?.type).toBe("compact_20260112");
+    expect(call.betas).toContain("compact-2026-01-12");
+  });
+
+  it("preserves compaction blocks across turns", async () => {
+    // Turn 1: max_tokens (forces a continuation turn) with a compaction block
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "max_tokens",
+        content: [
+          { type: "compaction", content: "earlier conversation summary" },
+          { type: "text", text: "new text after compaction" },
+        ],
+        usage: { input_tokens: 160_000, output_tokens: 4096 },
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "done" }],
+        usage: { input_tokens: 50_000, output_tokens: 100 },
+      },
+    ]);
+
+    await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "long request",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    // The second call's message history must include the compaction block on
+    // the assistant turn from message 1 (not just the text).
+    const secondCall = client.calls[1];
+    const assistantTurn = secondCall?.messages.find((m) => m.role === "assistant");
+    const blocks = assistantTurn?.content as Array<{ type: string }>;
+    expect(blocks.find((b) => b.type === "compaction")).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/loop.test.ts
+```
+
+- [ ] **Step 3: Extend the implementation**
+
+In `server-ts/src/mind/loop.ts`, update the `client.messages.create(...)` call to include `context_management` and `betas`:
+
+```typescript
+    const response = await client.messages.create({
+      model,
+      max_tokens: 4096,
+      system: systemPrompt,
+      tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+      messages,
+      cache_control: { type: "ephemeral" },
+      context_management: {
+        edits: [
+          {
+            type: "compact_20260112",
+            trigger: { type: "input_tokens", value: 150_000 },
+          },
+        ],
+      },
+      betas: ["compact-2026-01-12"],
+    } as any);
+```
+
+The existing logic already appends `response.content as unknown as Anthropic.Messages.ContentBlockParam[]` — that preserves compaction blocks since they stream through untouched.
+
+- [ ] **Step 4: Run test, verify PASS**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/loop.ts server-ts/src/mind/loop.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): enable server-side compaction
+
+Passes context_management with compact_20260112 edit + compact-2026-01-12
+beta header on every request. Compaction blocks in the response are
+preserved when we append response.content to the message history,
+so the API can drop pre-compaction messages on the next request.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Streaming mock + streaming mind loop
+
+**Files:**
+- Modify: `server-ts/src/mind/mock-client.ts`
+- Modify: `server-ts/src/mind/mock-client.test.ts`
+- Modify: `server-ts/src/mind/loop.ts`
+- Modify: `server-ts/src/mind/loop.test.ts`
+
+- [ ] **Step 1: Extend the mock client's test**
+
+Append to `server-ts/src/mind/mock-client.test.ts`:
+
+```typescript
+describe("MockAnthropicClient.messages.stream", () => {
+  it("yields queued delta strings and returns a final message", async () => {
+    const client = new MockAnthropicClient([], {
+      streams: [
+        { deltas: ["Hel", "lo!"], final: TEXT_MESSAGE },
+      ],
+    });
+
+    const stream = client.messages.stream({
+      model: "mock",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    const collected: string[] = [];
+    for await (const event of stream) {
+      if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+        collected.push(event.delta.text);
+      }
+    }
+    expect(collected).toEqual(["Hel", "lo!"]);
+    const final = await stream.finalMessage();
+    expect(final.content[0]).toEqual({ type: "text", text: "hello" });
+  });
+});
+```
+
+- [ ] **Step 2: Extend the mock client**
+
+Replace `stream: (): never => { throw ... }` in `server-ts/src/mind/mock-client.ts` with a real implementation:
+
+```typescript
+export type MockStream = {
+  deltas: string[];
+  final: MockMessage;
+};
+
+export class MockAnthropicClient implements MindClient {
+  readonly calls: CreateParams[] = [];
+  readonly streamCalls: CreateParams[] = [];
+  private readonly queue: MockMessage[];
+  private readonly streamQueue: MockStream[];
+
+  constructor(
+    responses: MockMessage[],
+    opts: { streams?: MockStream[] } = {},
+  ) {
+    this.queue = [...responses];
+    this.streamQueue = [...(opts.streams ?? [])];
+  }
+
+  readonly messages = {
+    create: async (params: CreateParams): Promise<MockMessage> => {
+      this.calls.push(params);
+      const next = this.queue.shift();
+      if (!next) throw new Error("MockAnthropicClient: no queued response");
+      return next;
+    },
+    stream: (params: CreateParams) => {
+      this.streamCalls.push(params);
+      const next = this.streamQueue.shift();
+      if (!next) throw new Error("MockAnthropicClient.stream: no queued stream");
+      const { deltas, final } = next;
+
+      async function* events() {
+        yield { type: "message_start", message: { id: final.id } };
+        yield { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } };
+        for (const delta of deltas) {
+          yield { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: delta } };
+        }
+        yield { type: "content_block_stop", index: 0 };
+        yield { type: "message_stop" };
+      }
+
+      const iter = events();
+      return {
+        [Symbol.asyncIterator]() {
+          return iter;
+        },
+        finalMessage: async () => final,
+      };
+    },
+  } as unknown as MindClient["messages"];
+}
+```
+
+Run mock tests, verify PASS.
+
+- [ ] **Step 3: Extend the mind loop's test**
+
+Append to `server-ts/src/mind/loop.test.ts`:
+
+```typescript
+import { runMindStreaming } from "./loop.js";
+
+describe("runMindStreaming", () => {
+  it("emits delta callbacks as text streams in", async () => {
+    const client = new MockAnthropicClient(
+      [],
+      {
+        streams: [
+          {
+            deltas: ["Hi ", "there"],
+            final: {
+              id: "msg_1",
+              role: "assistant",
+              model: "mock",
+              stop_reason: "end_turn",
+              content: [{ type: "text", text: "Hi there" }],
+              usage: { input_tokens: 10, output_tokens: 3 },
+            },
+          },
+        ],
+      },
+    );
+
+    const chunks: string[] = [];
+    const result = await runMindStreaming({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      onTextDelta: (text) => chunks.push(text),
+    });
+
+    expect(chunks).toEqual(["Hi ", "there"]);
+    expect(result.finalText).toBe("Hi there");
+  });
+});
+```
+
+- [ ] **Step 4: Extend the mind loop**
+
+Append to `server-ts/src/mind/loop.ts`:
+
+```typescript
+export type MindStreamingInputs = MindTurnInputs & {
+  onTextDelta: (text: string) => void;
+};
+
+export type MindStreamingResult = {
+  finalText: string;
+  assistantContent: ContentBlock[];
+  totalUsage: MindTurnResult["totalUsage"];
+};
+
+export async function runMindStreaming(
+  inputs: MindStreamingInputs,
+): Promise<MindStreamingResult> {
+  const { client, model, systemPrompt, tools, onTextDelta } = inputs;
+
+  const messages: Anthropic.Messages.MessageParam[] = [
+    ...conversationToMessages(inputs.conversation),
+    { role: "user", content: inputs.userMessage },
+  ];
+
+  const stream = client.messages.stream({
+    model,
+    max_tokens: 4096,
+    system: systemPrompt,
+    tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+    messages,
+    cache_control: { type: "ephemeral" },
+    context_management: {
+      edits: [{ type: "compact_20260112", trigger: { type: "input_tokens", value: 150_000 } }],
+    },
+    betas: ["compact-2026-01-12"],
+  } as any);
+
+  for await (const event of stream) {
+    if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+      onTextDelta(event.delta.text);
+    }
+  }
+
+  const final = await stream.finalMessage();
+  return {
+    finalText: final.content
+      .filter((b: { type: string }) => b.type === "text")
+      .map((b: unknown) => (b as { text: string }).text)
+      .join(""),
+    assistantContent: final.content as unknown as ContentBlock[],
+    totalUsage: {
+      input_tokens: final.usage.input_tokens,
+      output_tokens: final.usage.output_tokens,
+      cache_read_input_tokens: final.usage.cache_read_input_tokens ?? 0,
+      cache_creation_input_tokens: final.usage.cache_creation_input_tokens ?? 0,
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Run tests, verify PASS**
+
+- [ ] **Step 6: `pnpm check`**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server-ts/src/mind/loop.ts server-ts/src/mind/loop.test.ts server-ts/src/mind/mock-client.ts server-ts/src/mind/mock-client.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add streaming mind loop + streaming mock
+
+runMindStreaming uses messages.stream + finalMessage. Emits text deltas
+via a callback so the HTTP layer can broadcast ChatStreamDelta events in
+real time. Mock client now supports stream() for unit-testable streaming.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Budget integration
+
+**Files:**
+- Create: `server-ts/src/mind/budgeted-mind.ts`
+- Create: `server-ts/src/mind/budgeted-mind.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { recordSpend } from "../budget/ledger.js";
+import { runBudgetedMind } from "./budgeted-mind.js";
+import { MockAnthropicClient } from "./mock-client.js";
+
+describe("runBudgetedMind", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-bm-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("runs the mind and records spend on the ledger", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 1000, output_tokens: 200 },
+      },
+    ]);
+
+    const result = await runBudgetedMind({
+      client,
+      home,
+      slug: "alice",
+      day: "2026-04-22",
+      capUsd: 2.0,
+      model: "mock",
+      pricePerMTokIn: 3.0,
+      pricePerMTokOut: 15.0,
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    expect(result.downgraded).toBeUndefined();
+    const { loadDaily } = await import("../budget/ledger.js");
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    // 1000 * 3/1M + 200 * 15/1M = 0.003 + 0.003 = 0.006
+    expect(ledger.dollars_spent).toBeCloseTo(0.006, 4);
+    expect(ledger.calls).toBe(1);
+  });
+
+  it("downgrades when budget is suppressed without invoking the client", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 2.5,
+    });
+
+    const client = new MockAnthropicClient([
+      {
+        id: "should-not-run",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+
+    const result = await runBudgetedMind({
+      client,
+      home,
+      slug: "alice",
+      day: "2026-04-22",
+      capUsd: 2.0,
+      model: "mock",
+      pricePerMTokIn: 3.0,
+      pricePerMTokOut: 15.0,
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    expect(result.downgraded).toBe(true);
+    expect(client.calls).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/budgeted-mind.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import { chargeAndCall } from "../budget/charge-and-call.js";
+import type { ConversationEntry } from "../conversation/types.js";
+import type { MindClient } from "./anthropic-client.js";
+import { runMindWithTools, type MindFullTurnResult } from "./loop.js";
+import type { ToolDefinition } from "./skill-tool.js";
+
+export type BudgetedMindInputs = {
+  client: MindClient;
+  home: string;
+  slug: string;
+  day: string;
+  capUsd: number;
+  model: string;
+  pricePerMTokIn: number;
+  pricePerMTokOut: number;
+  systemPrompt: string;
+  tools: ToolDefinition[];
+  conversation: ConversationEntry[];
+  userMessage: string;
+  executeTool: (name: string, input: Record<string, unknown>) => Promise<string>;
+  maxIterations: number;
+};
+
+export type BudgetedMindResult =
+  | ({ downgraded: false } & MindFullTurnResult)
+  | { downgraded: true; reason: string };
+
+export async function runBudgetedMind(
+  inputs: BudgetedMindInputs,
+): Promise<BudgetedMindResult> {
+  const outcome = await chargeAndCall(
+    {
+      home: inputs.home,
+      slug: inputs.slug,
+      day: inputs.day,
+      capUsd: inputs.capUsd,
+      tier: 3,
+    },
+    async () => {
+      const result = await runMindWithTools({
+        client: inputs.client,
+        model: inputs.model,
+        systemPrompt: inputs.systemPrompt,
+        tools: inputs.tools,
+        conversation: inputs.conversation,
+        userMessage: inputs.userMessage,
+        executeTool: inputs.executeTool,
+        maxIterations: inputs.maxIterations,
+      });
+
+      const dollars =
+        (result.totalUsage.input_tokens * inputs.pricePerMTokIn) / 1_000_000 +
+        (result.totalUsage.output_tokens * inputs.pricePerMTokOut) / 1_000_000;
+
+      return {
+        ok: true as const,
+        value: result,
+        usage: {
+          tokens_in: result.totalUsage.input_tokens,
+          tokens_out: result.totalUsage.output_tokens,
+          dollars,
+        },
+      };
+    },
+  );
+
+  if ("downgraded" in outcome) {
+    return { downgraded: true, reason: outcome.reason };
+  }
+  if (!outcome.value) {
+    throw new Error("runBudgetedMind: expected value on success outcome");
+  }
+  return { downgraded: false, ...outcome.value };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (2 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/budgeted-mind.ts server-ts/src/mind/budgeted-mind.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): wrap mind loop in chargeAndCall
+
+runBudgetedMind gates every tier-3 mind invocation through the daily
+budget ledger. On suppressed state, returns a downgraded outcome without
+calling Anthropic. Token-to-dollar conversion uses per-million-token
+prices passed in by the caller (model-dependent).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: ServerEvent types + JSON wire format
+
+**Files:**
+- Create: `server-ts/src/events/server-event.ts`
+- Create: `server-ts/src/events/server-event.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { serializeServerEvent, type ServerEvent } from "./server-event.js";
+
+describe("serializeServerEvent", () => {
+  it("ChatMessageCreated matches the Rust wire format shape", () => {
+    const event: ServerEvent = {
+      type: "chat_message_created",
+      instance_slug: "alice",
+      chat_id: "default",
+      message: {
+        id: "msg_1",
+        role: "Assistant",
+        content: "hello",
+        created_at: "1714000000000",
+        kind: "Message",
+      },
+    };
+    const json = JSON.parse(serializeServerEvent(event));
+    expect(json.type).toBe("chat_message_created");
+    expect(json.instance_slug).toBe("alice");
+    expect(json.message.role).toBe("Assistant");
+  });
+
+  it("ChatStreamDelta carries message_id + delta", () => {
+    const event: ServerEvent = {
+      type: "chat_stream_delta",
+      instance_slug: "alice",
+      chat_id: "default",
+      message_id: "msg_2",
+      delta: "Hi ",
+    };
+    const json = JSON.parse(serializeServerEvent(event));
+    expect(json.type).toBe("chat_stream_delta");
+    expect(json.delta).toBe("Hi ");
+  });
+
+  it("AgentRunning / AgentStopped are bare signals", () => {
+    const running: ServerEvent = {
+      type: "agent_running",
+      instance_slug: "alice",
+      chat_id: "default",
+    };
+    const json = JSON.parse(serializeServerEvent(running));
+    expect(json).toEqual({
+      type: "agent_running",
+      instance_slug: "alice",
+      chat_id: "default",
+    });
+  });
+
+  it("ContextCompacting reports how many messages were compacted", () => {
+    const event: ServerEvent = {
+      type: "context_compacting",
+      instance_slug: "alice",
+      chat_id: "default",
+      messages_compacted: 42,
+    };
+    const json = JSON.parse(serializeServerEvent(event));
+    expect(json.messages_compacted).toBe(42);
+  });
+
+  it("ChatSnapshot replaces the whole chat state", () => {
+    const event: ServerEvent = {
+      type: "chat_snapshot",
+      instance_slug: "alice",
+      chat_id: "default",
+      messages: [],
+      agent_running: false,
+    };
+    const json = JSON.parse(serializeServerEvent(event));
+    expect(json.agent_running).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/events/server-event.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+/**
+ * ServerEvent — the WebSocket wire format. Byte-compatible with the Rust
+ * backend's existing serde(rename_all = "snake_case") tagged enum, so the
+ * SvelteKit client runs unmodified.
+ *
+ * This file intentionally defines only the variants Plan 2 emits. Plans 3
+ * (outreach), 4 (cross-instance), and 5 (polish) add the remaining variants
+ * (MoodUpdated, DropCreated, HeartbeatThought, McpAppStart, etc.) as their
+ * features land.
+ */
+export type ChatMessage = {
+  id: string;
+  role: "User" | "Assistant";
+  content: string;
+  created_at: string;
+  kind: "Message" | "ToolCall" | "ToolOutput" | "McpApp" | "Compaction";
+  tool_name?: string;
+  model?: string;
+};
+
+export type ServerEvent =
+  | {
+      type: "chat_message_created";
+      instance_slug: string;
+      chat_id: string;
+      message: ChatMessage;
+    }
+  | {
+      type: "chat_stream_delta";
+      instance_slug: string;
+      chat_id: string;
+      message_id: string;
+      delta: string;
+    }
+  | {
+      type: "agent_running";
+      instance_slug: string;
+      chat_id: string;
+    }
+  | {
+      type: "agent_stopped";
+      instance_slug: string;
+      chat_id: string;
+    }
+  | {
+      type: "context_compacting";
+      instance_slug: string;
+      chat_id: string;
+      messages_compacted: number;
+    }
+  | {
+      type: "chat_snapshot";
+      instance_slug: string;
+      chat_id: string;
+      messages: ChatMessage[];
+      agent_running: boolean;
+    };
+
+export function serializeServerEvent(event: ServerEvent): string {
+  return JSON.stringify(event);
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (5 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/events/server-event.ts server-ts/src/events/server-event.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add ServerEvent wire format
+
+Plan 2 subset of the Rust ServerEvent enum: chat_message_created,
+chat_stream_delta, agent_running/stopped, context_compacting,
+chat_snapshot. Byte-compatible with the existing client's JSON shape.
+Later plans extend this union.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: WebSocket broadcaster
+
+**Files:**
+- Create: `server-ts/src/events/broadcaster.ts`
+- Create: `server-ts/src/events/broadcaster.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, expect, it, vi } from "vitest";
+import { Broadcaster } from "./broadcaster.js";
+import type { ServerEvent } from "./server-event.js";
+
+describe("Broadcaster", () => {
+  it("delivers an event to every subscriber", () => {
+    const b = new Broadcaster();
+    const a = vi.fn();
+    const c = vi.fn();
+    b.subscribe(a);
+    b.subscribe(c);
+
+    const event: ServerEvent = {
+      type: "agent_running",
+      instance_slug: "alice",
+      chat_id: "default",
+    };
+    b.emit(event);
+
+    expect(a).toHaveBeenCalledWith(event);
+    expect(c).toHaveBeenCalledWith(event);
+  });
+
+  it("unsubscribe stops delivery", () => {
+    const b = new Broadcaster();
+    const a = vi.fn();
+    const unsub = b.subscribe(a);
+    unsub();
+    b.emit({ type: "agent_running", instance_slug: "x", chat_id: "y" });
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it("isolates subscriber exceptions from other subscribers", () => {
+    const b = new Broadcaster();
+    b.subscribe(() => {
+      throw new Error("boom");
+    });
+    const ok = vi.fn();
+    b.subscribe(ok);
+    b.emit({ type: "agent_running", instance_slug: "x", chat_id: "y" });
+    expect(ok).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/events/broadcaster.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import type { ServerEvent } from "./server-event.js";
+
+export type Subscriber = (event: ServerEvent) => void;
+
+/**
+ * In-process pub-sub for ServerEvents. WebSocket handlers call subscribe()
+ * on connect; the mind worker calls emit() as events fire.
+ * Subscriber exceptions are caught so one bad client can't break others.
+ */
+export class Broadcaster {
+  private readonly subs = new Set<Subscriber>();
+
+  subscribe(fn: Subscriber): () => void {
+    this.subs.add(fn);
+    return () => this.subs.delete(fn);
+  }
+
+  emit(event: ServerEvent): void {
+    for (const fn of this.subs) {
+      try {
+        fn(event);
+      } catch (err) {
+        console.error("Broadcaster: subscriber threw", err);
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (3 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/events/broadcaster.ts server-ts/src/events/broadcaster.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add in-process ServerEvent broadcaster
+
+Simple pub-sub. WebSocket handlers subscribe on connect; the mind worker
+emits as events fire. Subscriber errors are caught and logged, not
+propagated, so one bad client never breaks others.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Mind worker
+
+**Files:**
+- Create: `server-ts/src/mind/worker.ts`
+- Create: `server-ts/src/mind/worker.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Broadcaster } from "../events/broadcaster.js";
+import type { ServerEvent } from "../events/server-event.js";
+import { MindWorker } from "./worker.js";
+import { MockAnthropicClient } from "./mock-client.js";
+
+describe("MindWorker", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-worker-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("handles a chat message end-to-end and persists both turns", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "hi back" }],
+        usage: { input_tokens: 100, output_tokens: 10 },
+      },
+    ]);
+
+    const broadcaster = new Broadcaster();
+    const received: ServerEvent[] = [];
+    broadcaster.subscribe((e) => received.push(e));
+
+    const worker = new MindWorker({
+      client,
+      home,
+      slug: "alice",
+      chatId: "default",
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3.0,
+      pricePerMTokOut: 15.0,
+      broadcaster,
+    });
+
+    await worker.handleUserMessage("hello");
+
+    // Two broadcasts: AgentRunning (on start) and AgentStopped (on end),
+    // plus at least one ChatMessageCreated for the assistant reply.
+    const types = received.map((e) => e.type);
+    expect(types).toContain("agent_running");
+    expect(types).toContain("chat_message_created");
+    expect(types).toContain("agent_stopped");
+
+    // Conversation persisted: user turn + assistant turn.
+    const { loadConversation } = await import("../conversation/store.js");
+    const conv = await loadConversation(home, "alice", "default");
+    expect(conv.map((e) => e.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("tracks warm state: active after use, teardown-eligible after TTL", async () => {
+    const client = new MockAnthropicClient([]);
+    const worker = new MindWorker({
+      client,
+      home,
+      slug: "alice",
+      chatId: "default",
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3.0,
+      pricePerMTokOut: 15.0,
+      broadcaster: new Broadcaster(),
+      warmTtlMs: 1000,
+    });
+
+    worker.touch(1_000_000);
+    expect(worker.isStaleAt(1_000_500)).toBe(false);
+    expect(worker.isStaleAt(1_002_001)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/worker.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import { loadSkills } from "../skills/loader.js";
+import { loadTriageRules } from "../triage/rules.js";
+import { loadSettings } from "../settings/reader.js";
+import { todayUtc } from "../budget/ledger.js";
+import type { Broadcaster } from "../events/broadcaster.js";
+import {
+  type ChatMessage,
+  type ServerEvent,
+} from "../events/server-event.js";
+import {
+  appendConversationEntry,
+  loadConversation,
+} from "../conversation/store.js";
+import type { ConversationEntry } from "../conversation/types.js";
+import { instanceDir } from "../paths.js";
+import type { MindClient } from "./anthropic-client.js";
+import { runBudgetedMind } from "./budgeted-mind.js";
+import { buildSystemPrompt } from "./system-prompt.js";
+import { builtInTools, skillToTool } from "./skill-tool.js";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const DEFAULT_WARM_TTL_MS = 10 * 60 * 1000;
+
+export type MindWorkerOptions = {
+  client: MindClient;
+  home: string;
+  slug: string;
+  chatId: string;
+  companyName: string;
+  model: string;
+  pricePerMTokIn: number;
+  pricePerMTokOut: number;
+  broadcaster: Broadcaster;
+  warmTtlMs?: number;
+};
+
+async function tryReadFile(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw err;
+  }
+}
+
+export class MindWorker {
+  private lastActivityMs = Date.now();
+  private readonly warmTtlMs: number;
+
+  constructor(private readonly opts: MindWorkerOptions) {
+    this.warmTtlMs = opts.warmTtlMs ?? DEFAULT_WARM_TTL_MS;
+  }
+
+  touch(nowMs = Date.now()): void {
+    this.lastActivityMs = nowMs;
+  }
+
+  isStaleAt(nowMs: number): boolean {
+    return nowMs - this.lastActivityMs > this.warmTtlMs;
+  }
+
+  async handleUserMessage(text: string): Promise<void> {
+    const { home, slug, chatId, broadcaster } = this.opts;
+    this.touch();
+
+    broadcaster.emit({ type: "agent_running", instance_slug: slug, chat_id: chatId });
+
+    try {
+      const userEntry: ConversationEntry = {
+        id: `msg_${Date.now()}_u`,
+        role: "user",
+        content: [{ type: "text", text }],
+        ts: Date.now(),
+      };
+      await appendConversationEntry(home, slug, chatId, userEntry);
+
+      const userMsg: ChatMessage = {
+        id: userEntry.id,
+        role: "User",
+        content: text,
+        created_at: String(userEntry.ts),
+        kind: "Message",
+      };
+      broadcaster.emit({
+        type: "chat_message_created",
+        instance_slug: slug,
+        chat_id: chatId,
+        message: userMsg,
+      });
+
+      // Assemble context
+      const instDir = instanceDir(home, slug);
+      const [soul, mood, rhythm, enabledSkills, triageRules, settings, conversation] =
+        await Promise.all([
+          tryReadFile(join(instDir, "soul.md")),
+          tryReadFile(join(instDir, "mood.md")),
+          tryReadFile(join(instDir, "rhythm.json")),
+          loadSkills(home, slug, { enabledOnly: true }),
+          loadTriageRules(home, slug),
+          loadSettings(home, slug),
+          loadConversation(home, slug, chatId),
+        ]);
+
+      const systemPrompt = buildSystemPrompt({
+        employeeName: slug,
+        companyName: this.opts.companyName,
+        soul,
+        mood,
+        rhythm,
+        enabledSkills,
+        triageRules,
+      });
+
+      const tools = [...builtInTools(), ...enabledSkills.map(skillToTool)];
+
+      const outcome = await runBudgetedMind({
+        client: this.opts.client,
+        home,
+        slug,
+        day: todayUtc(),
+        capUsd: settings.daily_budget_usd,
+        model: this.opts.model,
+        pricePerMTokIn: this.opts.pricePerMTokIn,
+        pricePerMTokOut: this.opts.pricePerMTokOut,
+        systemPrompt,
+        tools,
+        // Don't include the just-appended user entry twice — pass the pre-append
+        // conversation and runBudgetedMind adds it as userMessage.
+        conversation,
+        userMessage: text,
+        executeTool: async (name) => `[${name} not wired in Plan 2]`,
+        maxIterations: 10,
+      });
+
+      if (outcome.downgraded) {
+        broadcaster.emit({ type: "agent_stopped", instance_slug: slug, chat_id: chatId });
+        return;
+      }
+
+      const assistantEntry: ConversationEntry = {
+        id: `msg_${Date.now()}_a`,
+        role: "assistant",
+        content: outcome.assistantContent,
+        ts: Date.now(),
+        model: this.opts.model,
+      };
+      await appendConversationEntry(home, slug, chatId, assistantEntry);
+
+      broadcaster.emit({
+        type: "chat_message_created",
+        instance_slug: slug,
+        chat_id: chatId,
+        message: {
+          id: assistantEntry.id,
+          role: "Assistant",
+          content: outcome.finalText,
+          created_at: String(assistantEntry.ts),
+          kind: "Message",
+          model: this.opts.model,
+        },
+      });
+    } finally {
+      broadcaster.emit({ type: "agent_stopped", instance_slug: slug, chat_id: chatId });
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (2 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/worker.ts server-ts/src/mind/worker.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add MindWorker — per-employee chat handler
+
+Assembles system prompt from soul/mood/rhythm/skills/triage, loads
+conversation, runs runBudgetedMind, persists both turns, broadcasts
+AgentRunning / ChatMessageCreated / AgentStopped. Tracks warm TTL so
+the worker pool (Task 18) can tear down idle workers.
+
+Tool execution is stubbed — real outreach + cross-instance wiring lands
+in Plans 4 and 5.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: Worker pool
+
+**Files:**
+- Create: `server-ts/src/mind/pool.ts`
+- Create: `server-ts/src/mind/pool.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Broadcaster } from "../events/broadcaster.js";
+import { MockAnthropicClient } from "./mock-client.js";
+import { WorkerPool } from "./pool.js";
+
+describe("WorkerPool", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-pool-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("creates one worker per (slug, chatId) on demand", () => {
+    const pool = new WorkerPool({
+      clientFactory: () => new MockAnthropicClient([]),
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster: new Broadcaster(),
+    });
+
+    const a = pool.get("alice", "default");
+    const a2 = pool.get("alice", "default");
+    const b = pool.get("bob", "default");
+
+    expect(a).toBe(a2);
+    expect(a).not.toBe(b);
+  });
+
+  it("sweepStale removes workers past their TTL", () => {
+    const pool = new WorkerPool({
+      clientFactory: () => new MockAnthropicClient([]),
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster: new Broadcaster(),
+      warmTtlMs: 1000,
+    });
+
+    const w = pool.get("alice", "default");
+    w.touch(1_000_000);
+    pool.sweepStale(1_000_500);
+    expect(pool.get("alice", "default")).toBe(w);
+
+    pool.sweepStale(1_100_000);
+    expect(pool.get("alice", "default")).not.toBe(w);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/mind/pool.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import type { Broadcaster } from "../events/broadcaster.js";
+import type { MindClient } from "./anthropic-client.js";
+import { MindWorker } from "./worker.js";
+
+export type WorkerPoolOptions = {
+  clientFactory: () => MindClient;
+  home: string;
+  companyName: string;
+  model: string;
+  pricePerMTokIn: number;
+  pricePerMTokOut: number;
+  broadcaster: Broadcaster;
+  warmTtlMs?: number;
+};
+
+export class WorkerPool {
+  private readonly workers = new Map<string, MindWorker>();
+
+  constructor(private readonly opts: WorkerPoolOptions) {}
+
+  private key(slug: string, chatId: string): string {
+    return `${slug}/${chatId}`;
+  }
+
+  get(slug: string, chatId: string): MindWorker {
+    const k = this.key(slug, chatId);
+    const existing = this.workers.get(k);
+    if (existing) return existing;
+
+    const worker = new MindWorker({
+      client: this.opts.clientFactory(),
+      home: this.opts.home,
+      slug,
+      chatId,
+      companyName: this.opts.companyName,
+      model: this.opts.model,
+      pricePerMTokIn: this.opts.pricePerMTokIn,
+      pricePerMTokOut: this.opts.pricePerMTokOut,
+      broadcaster: this.opts.broadcaster,
+      ...(this.opts.warmTtlMs !== undefined ? { warmTtlMs: this.opts.warmTtlMs } : {}),
+    });
+    this.workers.set(k, worker);
+    return worker;
+  }
+
+  sweepStale(nowMs: number): void {
+    for (const [k, w] of this.workers) {
+      if (w.isStaleAt(nowMs)) this.workers.delete(k);
+    }
+  }
+
+  size(): number {
+    return this.workers.size;
+  }
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (2 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/mind/pool.ts server-ts/src/mind/pool.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add WorkerPool
+
+Lazy-start MindWorker per (slug, chat_id), reused for subsequent messages.
+sweepStale() is called periodically by the main loop (Task 21) to tear
+down idle workers past their warm TTL.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 19: HTTP auth middleware
+
+**Files:**
+- Create: `server-ts/src/http/auth.ts`
+- Create: `server-ts/src/http/auth.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { requireAuth } from "./auth.js";
+
+function app(authToken: string | undefined) {
+  const h = new Hono();
+  h.use("*", requireAuth(authToken));
+  h.get("/ok", (c) => c.text("ok"));
+  return h;
+}
+
+describe("requireAuth", () => {
+  it("passes through when authToken is undefined (no auth configured)", async () => {
+    const res = await app(undefined).request("/ok");
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a matching Bearer token", async () => {
+    const res = await app("secret").request("/ok", {
+      headers: { Authorization: "Bearer secret" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a matching ?token= query param (for WebSocket)", async () => {
+    const res = await app("secret").request("/ok?token=secret");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 with no token", async () => {
+    const res = await app("secret").request("/ok");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 with a wrong token", async () => {
+    const res = await app("secret").request("/ok", {
+      headers: { Authorization: "Bearer wrong" },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/http/auth.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Bearer-token or ?token= query-param auth.
+ * - If authToken is undefined, auth is disabled (dev).
+ * - Otherwise, requests must supply the token via either channel.
+ */
+export function requireAuth(authToken: string | undefined): MiddlewareHandler {
+  return async (c, next) => {
+    if (!authToken) return next();
+
+    const header = c.req.header("authorization") ?? "";
+    const bearer = header.startsWith("Bearer ") ? header.slice(7) : "";
+    const query = c.req.query("token") ?? "";
+
+    if (bearer === authToken || query === authToken) {
+      return next();
+    }
+    return c.text("Unauthorized", 401);
+  };
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (5 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/http/auth.ts server-ts/src/http/auth.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add bearer-token auth middleware
+
+Mirrors the Rust backend: Authorization: Bearer <token> or ?token=<...>
+query param. When authToken is undefined, auth is disabled (dev mode).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 20: Hono server — chat + WebSocket
+
+**Files:**
+- Create: `server-ts/src/http/server.ts`
+- Create: `server-ts/src/http/server.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Broadcaster } from "../events/broadcaster.js";
+import { MockAnthropicClient } from "../mind/mock-client.js";
+import { WorkerPool } from "../mind/pool.js";
+import { createApp } from "./server.js";
+
+describe("createApp", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-http-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("POST /api/chat returns 202 and triggers the mind worker", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "ack" }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+    const broadcaster = new Broadcaster();
+    const pool = new WorkerPool({
+      clientFactory: () => client,
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster,
+    });
+    const app = createApp({ authToken: undefined, pool, broadcaster });
+
+    const res = await app.request("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ instance_slug: "alice", chat_id: "default", content: "hi" }),
+    });
+
+    expect(res.status).toBe(202);
+  });
+
+  it("POST /api/chat requires auth when configured", async () => {
+    const pool = new WorkerPool({
+      clientFactory: () => new MockAnthropicClient([]),
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster: new Broadcaster(),
+    });
+    const app = createApp({ authToken: "secret", pool, broadcaster: new Broadcaster() });
+
+    const res = await app.request("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ instance_slug: "x", chat_id: "y", content: "hi" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/health returns 200", async () => {
+    const pool = new WorkerPool({
+      clientFactory: () => new MockAnthropicClient([]),
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster: new Broadcaster(),
+    });
+    const app = createApp({ authToken: undefined, pool, broadcaster: new Broadcaster() });
+
+    const res = await app.request("/api/health");
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+```bash
+pnpm test src/http/server.test.ts
+```
+
+- [ ] **Step 3: Write implementation**
+
+```typescript
+import { Hono } from "hono";
+import type { Broadcaster } from "../events/broadcaster.js";
+import type { WorkerPool } from "../mind/pool.js";
+import { requireAuth } from "./auth.js";
+
+export type AppOptions = {
+  authToken: string | undefined;
+  pool: WorkerPool;
+  broadcaster: Broadcaster;
+};
+
+export function createApp(opts: AppOptions) {
+  const app = new Hono();
+
+  app.get("/api/health", (c) => c.json({ ok: true }));
+
+  app.use("/api/*", requireAuth(opts.authToken));
+
+  app.post("/api/chat", async (c) => {
+    const body = await c.req.json<{
+      instance_slug: string;
+      chat_id: string;
+      content: string;
+    }>();
+
+    const worker = opts.pool.get(body.instance_slug, body.chat_id);
+    // Fire-and-forget: the mind turn runs asynchronously and broadcasts
+    // progress over WebSocket. The HTTP caller just gets a 202.
+    void worker.handleUserMessage(body.content).catch((err) => {
+      console.error("mind worker error", err);
+    });
+    return c.body(null, 202);
+  });
+
+  return app;
+}
+```
+
+- [ ] **Step 4: Run test, verify PASS (3 tests)**
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/http/server.ts server-ts/src/http/server.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add Hono app with /api/chat and /api/health
+
+POST /api/chat is fire-and-forget: returns 202, the MindWorker runs
+asynchronously and broadcasts ChatStreamDelta + ChatMessageCreated over
+the WebSocket channel. GET /api/health is an unauthed liveness probe.
+
+Auth middleware applies to all /api/* except /api/health.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 21: WebSocket endpoint
+
+**Files:**
+- Modify: `server-ts/src/http/server.ts`
+- Create: `server-ts/src/http/ws.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `server-ts/src/http/ws.ts`:
+
+```typescript
+import type { Broadcaster } from "../events/broadcaster.js";
+import { serializeServerEvent } from "../events/server-event.js";
+
+/**
+ * Wire a Hono WebSocket to the Broadcaster. Returns a handler usable with
+ * @hono/node-ws's upgradeWebSocket.
+ *
+ * Auth is handled by the upgrade path (middleware + ?token= query param).
+ */
+export function wsHandler(broadcaster: Broadcaster) {
+  return () => ({
+    onOpen(_evt: unknown, ws: { send: (data: string) => void; close: () => void }) {
+      const unsub = broadcaster.subscribe((event) => {
+        try {
+          ws.send(serializeServerEvent(event));
+        } catch {
+          unsub();
+          ws.close();
+        }
+      });
+      (ws as unknown as { _unsub?: () => void })._unsub = unsub;
+    },
+    onClose(_evt: unknown, ws: { _unsub?: () => void }) {
+      ws._unsub?.();
+    },
+    onError(_evt: unknown, ws: { _unsub?: () => void }) {
+      ws._unsub?.();
+    },
+    onMessage: () => {
+      // Clients don't need to send messages over WS — chat goes through POST /api/chat
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Wire into the Hono app**
+
+Modify `server-ts/src/http/server.ts` to register the WebSocket route. Replace the current `createApp` with:
+
+```typescript
+import { Hono } from "hono";
+import { createNodeWebSocket } from "@hono/node-ws";
+import type { Broadcaster } from "../events/broadcaster.js";
+import type { WorkerPool } from "../mind/pool.js";
+import { requireAuth } from "./auth.js";
+import { wsHandler } from "./ws.js";
+
+export type AppOptions = {
+  authToken: string | undefined;
+  pool: WorkerPool;
+  broadcaster: Broadcaster;
+};
+
+export function createApp(opts: AppOptions) {
+  const app = new Hono();
+  const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
+
+  app.get("/api/health", (c) => c.json({ ok: true }));
+
+  app.use("/api/*", requireAuth(opts.authToken));
+
+  app.post("/api/chat", async (c) => {
+    const body = await c.req.json<{
+      instance_slug: string;
+      chat_id: string;
+      content: string;
+    }>();
+
+    const worker = opts.pool.get(body.instance_slug, body.chat_id);
+    void worker.handleUserMessage(body.content).catch((err) => {
+      console.error("mind worker error", err);
+    });
+    return c.body(null, 202);
+  });
+
+  app.get("/api/ws", upgradeWebSocket(wsHandler(opts.broadcaster)));
+
+  return { app, injectWebSocket };
+}
+```
+
+Update the existing tests in `server-ts/src/http/server.test.ts` to destructure: replace `const app = createApp(...)` with `const { app } = createApp(...)` everywhere.
+
+- [ ] **Step 3: Run tests, verify PASS**
+
+Run `pnpm test src/http/` — both `auth.test.ts` and `server.test.ts` should pass.
+
+- [ ] **Step 4: `pnpm check`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/http/server.ts server-ts/src/http/server.test.ts server-ts/src/http/ws.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add WebSocket endpoint at /api/ws
+
+Wires the in-process Broadcaster to a @hono/node-ws upgrade handler.
+Every ServerEvent emitted by the worker pool gets serialized to JSON
+and pushed to every connected client. Clients don't send messages over
+WS — chat goes through POST /api/chat.
+
+Auth is enforced via the standard auth middleware using ?token= on the
+upgrade request.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 22: main.ts — boot + shutdown
+
+**Files:**
+- Create: `server-ts/src/main.ts`
+
+- [ ] **Step 1: Write the file**
+
+```typescript
+import { serve } from "@hono/node-server";
+import { Broadcaster } from "./events/broadcaster.js";
+import { createAnthropicClient } from "./mind/anthropic-client.js";
+import { WorkerPool } from "./mind/pool.js";
+import { createApp } from "./http/server.js";
+import { loadConfig } from "./config.js";
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const SONNET_PRICE_IN = 3.0;   // $/M input tokens
+const SONNET_PRICE_OUT = 15.0; // $/M output tokens
+const STALE_SWEEP_MS = 60_000; // once a minute
+
+function getCompanyName(env: NodeJS.ProcessEnv): string {
+  return env.BOLLY_COMPANY_NAME ?? "your company";
+}
+
+async function main() {
+  const config = loadConfig(process.env as Record<string, string | undefined>);
+
+  const broadcaster = new Broadcaster();
+  const pool = new WorkerPool({
+    clientFactory: () => createAnthropicClient(config.anthropicApiKey),
+    home: config.bollyHome,
+    companyName: getCompanyName(process.env),
+    model: DEFAULT_MODEL,
+    pricePerMTokIn: SONNET_PRICE_IN,
+    pricePerMTokOut: SONNET_PRICE_OUT,
+    broadcaster,
+  });
+
+  const { app, injectWebSocket } = createApp({
+    authToken: config.authToken,
+    pool,
+    broadcaster,
+  });
+
+  const server = serve({
+    fetch: app.fetch,
+    port: config.httpPort,
+  });
+  injectWebSocket(server);
+
+  const sweepInterval = setInterval(() => pool.sweepStale(Date.now()), STALE_SWEEP_MS);
+
+  const shutdown = (signal: string) => {
+    console.log(`received ${signal}, shutting down`);
+    clearInterval(sweepInterval);
+    server.close(() => {
+      process.exit(0);
+    });
+    setTimeout(() => process.exit(1), 10_000).unref();
+  };
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+
+  console.log(`Bolly v1.0 listening on port ${config.httpPort}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Add a start script**
+
+Edit `server-ts/package.json` to add:
+
+```json
+    "start": "node dist/main.js",
+    "dev": "tsc --watch & node --enable-source-maps --watch dist/main.js"
+```
+
+(Keep the existing `build`, `test`, `check` scripts.)
+
+- [ ] **Step 3: Verify it builds**
+
+```bash
+pnpm build
+```
+
+Expected: `dist/main.js` is produced.
+
+**Note:** actually starting the server requires real `ANTHROPIC_API_KEY` + `BOLLY_HOME`. This task doesn't run it — only verifies compilation. The E2E test in Task 24 starts the server with a mock client.
+
+- [ ] **Step 4: `pnpm check`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/main.ts server-ts/package.json
+git commit -m "$(cat <<'EOF'
+feat(server-ts): add main entry point
+
+Wires Broadcaster → WorkerPool → Hono app → @hono/node-server.
+Stale workers are swept every minute. SIGTERM/SIGINT flush and exit;
+a 10-second timeout forces exit if anything hangs.
+
+Adds pnpm start and pnpm dev scripts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 23: Public API re-exports
+
+**Files:**
+- Modify: `server-ts/src/index.ts`
+- Modify: `server-ts/src/index.test.ts`
+
+- [ ] **Step 1: Extend the test**
+
+Append to `server-ts/src/index.test.ts`:
+
+```typescript
+describe("Plan 2 public API", () => {
+  it("re-exports runtime config, conversation store, mind, events, http", () => {
+    expect(api.loadConfig).toBeTypeOf("function");
+    expect(api.loadConversation).toBeTypeOf("function");
+    expect(api.appendConversationEntry).toBeTypeOf("function");
+    expect(api.buildSystemPrompt).toBeTypeOf("function");
+    expect(api.skillToTool).toBeTypeOf("function");
+    expect(api.builtInTools).toBeTypeOf("function");
+    expect(api.createAnthropicClient).toBeTypeOf("function");
+    expect(api.MockAnthropicClient).toBeTypeOf("function");
+    expect(api.runMindTurn).toBeTypeOf("function");
+    expect(api.runMindWithTools).toBeTypeOf("function");
+    expect(api.runMindStreaming).toBeTypeOf("function");
+    expect(api.runBudgetedMind).toBeTypeOf("function");
+    expect(api.MindWorker).toBeTypeOf("function");
+    expect(api.WorkerPool).toBeTypeOf("function");
+    expect(api.Broadcaster).toBeTypeOf("function");
+    expect(api.serializeServerEvent).toBeTypeOf("function");
+    expect(api.createApp).toBeTypeOf("function");
+    expect(api.requireAuth).toBeTypeOf("function");
+  });
+});
+```
+
+- [ ] **Step 2: Extend index.ts**
+
+Append to `server-ts/src/index.ts`:
+
+```typescript
+// Plan 2 — Mind runtime
+export { loadConfig, type RuntimeConfig } from "./config.js";
+
+export {
+  loadConversation,
+  saveConversation,
+  appendConversationEntry,
+} from "./conversation/store.js";
+export {
+  ContentBlockSchema,
+  ConversationEntrySchema,
+  ConversationSchema,
+  type ContentBlock,
+  type ConversationEntry,
+  type Conversation,
+} from "./conversation/types.js";
+
+export { buildSystemPrompt, type SystemPromptInputs } from "./mind/system-prompt.js";
+export {
+  skillToTool,
+  skillToToolName,
+  builtInTools,
+  type ToolDefinition,
+} from "./mind/skill-tool.js";
+export { createAnthropicClient, type MindClient } from "./mind/anthropic-client.js";
+export { MockAnthropicClient, type MockMessage, type MockStream } from "./mind/mock-client.js";
+export {
+  runMindTurn,
+  runMindWithTools,
+  runMindStreaming,
+  type MindTurnInputs,
+  type MindTurnResult,
+  type MindFullTurnInputs,
+  type MindFullTurnResult,
+  type MindStreamingInputs,
+  type MindStreamingResult,
+} from "./mind/loop.js";
+export { runBudgetedMind, type BudgetedMindResult } from "./mind/budgeted-mind.js";
+export { MindWorker, type MindWorkerOptions } from "./mind/worker.js";
+export { WorkerPool, type WorkerPoolOptions } from "./mind/pool.js";
+
+export { Broadcaster, type Subscriber } from "./events/broadcaster.js";
+export {
+  serializeServerEvent,
+  type ServerEvent,
+  type ChatMessage,
+} from "./events/server-event.js";
+
+export { createApp, type AppOptions } from "./http/server.js";
+export { requireAuth } from "./http/auth.js";
+```
+
+- [ ] **Step 3: Run index test, verify PASS**
+
+```bash
+pnpm test src/index.test.ts
+```
+
+- [ ] **Step 4: Run full suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass (should be 140+ tests across ~30 files).
+
+- [ ] **Step 5: `pnpm check`**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server-ts/src/index.ts server-ts/src/index.test.ts
+git commit -m "$(cat <<'EOF'
+feat(server-ts): extend public API with Plan 2 surface
+
+Re-exports the mind runtime (loop, worker, pool, client factory, mock),
+conversation store, system prompt assembler, skill-tool mapping, events
+(broadcaster, ServerEvent), HTTP app + auth middleware, and runtime config.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 24: End-to-end integration test
+
+**Files:**
+- Create: `server-ts/src/e2e.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Broadcaster } from "./events/broadcaster.js";
+import type { ServerEvent } from "./events/server-event.js";
+import { MockAnthropicClient } from "./mind/mock-client.js";
+import { WorkerPool } from "./mind/pool.js";
+import { createApp } from "./http/server.js";
+
+describe("E2E: HTTP chat → mind worker → WebSocket-style broadcast", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-e2e-"));
+    // Seed a minimal instance with soul.md
+    const instDir = join(home, "instances", "alice");
+    await mkdir(instDir, { recursive: true });
+    await writeFile(join(instDir, "soul.md"), "Alice's Bolly is helpful.");
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("POST /api/chat produces a full event sequence matching the Rust wire format", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_assist",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "Hi Alice, what's up?" }],
+        usage: { input_tokens: 200, output_tokens: 50 },
+      },
+    ]);
+
+    const broadcaster = new Broadcaster();
+    const received: ServerEvent[] = [];
+    broadcaster.subscribe((e) => received.push(e));
+
+    const pool = new WorkerPool({
+      clientFactory: () => client,
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster,
+    });
+
+    const { app } = createApp({ authToken: undefined, pool, broadcaster });
+
+    const res = await app.request("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        instance_slug: "alice",
+        chat_id: "default",
+        content: "hey",
+      }),
+    });
+    expect(res.status).toBe(202);
+
+    // handleUserMessage is fire-and-forget; wait for the worker to finish
+    // by polling for the AgentStopped event.
+    for (let i = 0; i < 100 && !received.some((e) => e.type === "agent_stopped"); i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    const types = received.map((e) => e.type);
+    expect(types).toContain("agent_running");
+    expect(types.filter((t) => t === "chat_message_created")).toHaveLength(2); // user + assistant
+    expect(types).toContain("agent_stopped");
+
+    // Verify the wire format is valid JSON the client expects
+    const assistantMsg = received.find(
+      (e): e is Extract<ServerEvent, { type: "chat_message_created" }> =>
+        e.type === "chat_message_created" && e.message.role === "Assistant",
+    );
+    expect(assistantMsg?.message.content).toBe("Hi Alice, what's up?");
+    expect(assistantMsg?.message.kind).toBe("Message");
+    expect(assistantMsg?.message.model).toBe("mock");
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E test**
+
+```bash
+pnpm test src/e2e.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass across the whole codebase (~150+ tests).
+
+- [ ] **Step 4: `pnpm check`**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server-ts/src/e2e.test.ts
+git commit -m "$(cat <<'EOF'
+test(server-ts): add E2E integration test for chat → mind → broadcast
+
+Seeds a minimal instance (soul.md only), posts to /api/chat, waits for
+AgentStopped, verifies the exact event sequence and that the ChatMessageCreated
+wire format is compatible with the SvelteKit client.
+
+Covers everything from Plan 2 end-to-end with the mock Anthropic client.
+Does not run against real Claude — that's Plan 6's cost-validation test.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 25: Milestone tag + README note
+
+**Files:**
+- Create: `server-ts/README.md`
+
+- [ ] **Step 1: Write a minimal README**
+
+```markdown
+# @bolly/server
+
+The Bolly v1.0 server runtime. Self-hosted AI coworker for teams.
+
+## Status
+
+**Plan 1** ✅ Foundations (types, paths, budget ledger, skills parser, triage helpers, settings reader) — 82 tests.
+**Plan 2** ✅ Mind runtime (Messages API loop with tool use, caching, compaction, streaming; HTTP server; WebSocket broadcast) — 150+ tests.
+**Plans 3–6** pending: event queue + triage execution, outreach delivery, cross-instance, polish + cost validation.
+
+## Development
+
+```bash
+pnpm install
+pnpm check      # tsc --noEmit + biome check
+pnpm test       # vitest run
+pnpm test:watch # vitest watch
+pnpm build      # → dist/
+pnpm start      # node dist/main.js (requires ANTHROPIC_API_KEY + BOLLY_HOME)
+```
+
+## Configuration (env)
+
+| Variable             | Required | Default | Purpose                                           |
+|----------------------|----------|---------|---------------------------------------------------|
+| `ANTHROPIC_API_KEY`  | yes      |         | Anthropic API key (company or BYOK per-employee) |
+| `BOLLY_HOME`         | yes      |         | Path to workspace root (`instances/`, `shared/`) |
+| `BOLLY_HTTP_PORT`    | no       | `4242`  | HTTP listen port                                  |
+| `BOLLY_AUTH_TOKEN`   | no       |         | Bearer token for `/api/*` (disabled when unset)   |
+| `BOLLY_COMPANY_NAME` | no       | `your company` | Rendered in the system prompt            |
+
+## Architecture
+
+See `docs/superpowers/specs/2026-04-22-bolly-v1-redesign-design.md`.
+```
+
+- [ ] **Step 2: Commit and tag**
+
+```bash
+git add server-ts/README.md
+git commit -m "$(cat <<'EOF'
+docs(server-ts): add README with run / test / env reference
+
+Documents where Plan 1 and Plan 2 land in the roadmap and how to run the
+server in development.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git tag -a mind-runtime-complete -m "Plan 2 complete: mind runtime, HTTP + WebSocket, budget-gated Anthropic loop"
+```
+
+Do not push the tag — the user reviews before pushing.
+
+---
+
+## Self-Review Checklist
+
+Before declaring Plan 2 done, the executor should confirm:
+
+- [ ] All 25 tasks committed (25 feat/test/chore commits on `bolly-v1-redesign`).
+- [ ] `pnpm test` reports 150+ tests passing.
+- [ ] `pnpm check` has no errors.
+- [ ] `pnpm build` produces `dist/main.js`.
+- [ ] `git log --oneline main..HEAD` shows a clean sequence with no TODO/WIP commits.
+- [ ] `server-ts/src/index.ts` exports every module Plan 3 will consume.
+- [ ] The `foundations-complete` tag still points at Plan 1's head; `mind-runtime-complete` is at Plan 2's.
+
+## What Plan 2 does NOT do (Plan 3 picks it up)
+
+- No event queue — user messages currently enter via `POST /api/chat` directly, not through a normalized event envelope. Plan 3 adds the queue + Tier 2 Haiku triage.
+- No scheduled jobs — the scheduler service that enqueues `source: scheduled` events lands in Plan 3.
+- No idle timer — the "user has been quiet for N minutes" source also lands in Plan 3.
+- No real outreach — `send_push`, `send_email`, `defer_for_digest` are declared as tools, but Plan 2's `executeTool` returns a placeholder string. Plan 4 wires real delivery.
+- No cross-instance — inter-Bolly events via `shared/channel/` land in Plan 5.
+- No end-to-end cost validation — the 24h-simulation gate is Plan 6.
+
+Plan 3 (Events & Triage, ~2 weeks) consumes this surface: `WorkerPool`, `Broadcaster`, `runBudgetedMind`, and the `Event` type from Plan 1's foundations. Expected ship: event queue with dedupe + backpressure, Haiku-backed triage gate, scheduled-job runner, cross-instance channel watcher (stub).

--- a/docs/superpowers/specs/2026-04-22-bolly-v1-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-22-bolly-v1-redesign-design.md
@@ -1,0 +1,667 @@
+# Bolly v1.0 — Runtime & Multi-Agent Redesign
+
+- **Date:** 2026-04-22
+- **Status:** Draft for review
+- **Authors:** Timur Turatbekov (w/ Claude)
+- **Scope:** Complete rewrite of the Bolly server runtime; new agent model; cost-optimized event-driven heartbeat; cross-instance support
+
+## TL;DR
+
+Bolly repositions as a **self-hosted AI coworker for companies**. The Rust backend is replaced by a TypeScript service that drives the **Claude Messages API** directly with custom tools, server-side compaction, and prompt caching. The 10-minute polling heartbeat (costing ~$20/user/day) is replaced by an event-driven three-tier architecture: pure-code event sources → cheap Haiku triage → Messages-API mind loop on escalation only. `ChildAgentConfig` TOML files become NL-configured **skills** (markdown with YAML frontmatter). Each company deploys one `$BOLLY_HOME` with `instances/{employee}/` per user and a shared `shared/` directory for company-wide memory and inter-Bolly coordination. Target: $20–50/employee/month economics, under 4,000 LoC, 10-week timeline, shipped as v1.0 with no backward compatibility.
+
+## Context
+
+### Current state
+
+- **Backend:** Rust/Axum single-binary server with embedded SvelteKit client (rust-embed), running an Agent loop over LLM providers (Anthropic + OpenAI).
+- **Agent model:** `ChildAgentConfig` TOML files define "child agents" — each with its own hourly-cadence heartbeat loop (`server/src/services/heartbeat.rs`).
+- **Cost:** measured at ~$20/user/day under the 10-minute default heartbeat. Unsustainable at any pricing model.
+- **Single-provider friction:** OpenAI branch measured to be weak at computer use; the dual-provider surface doubles maintenance for little benefit.
+- **Product positioning:** today sold/used as a personal AI companion; v1 repositions to a team-deployed AI coworker that lives inside a company's context.
+
+### Why redesign
+
+Four pains drove this work:
+
+1. **The heartbeat is a cron, not a heartbeat.** It fires on a timer regardless of context, burning tokens whether anything is happening or not. Bolly needs to feel alive, not mechanical.
+2. **Multi-agent orchestration is too rigid.** `ChildAgentConfig` is hand-edited TOML with hourly intervals. There is no runtime coordination between agents, and no way for a user to shape an agent through natural language.
+3. **The Rust agent loop is doing work the Messages API does better.** Stop-reason handling, tool dispatch, and compaction are all first-class features of `/v1/messages` now (`context_management` for compaction, native tool use, prompt caching). Porting to a thin TypeScript loop on the Messages API cuts ~2,000 LoC of Rust and gets us ZDR, caching, and compaction for free. Competitors like [NanoClaw](https://github.com/qwibitai/nanoclaw) demonstrate that small, focused TS agent codebases can reach adoption quickly.
+4. **The consumer positioning is too crowded.** Replika, Nomi, Kindroid own persona-first companions. Bolly's differentiator — autonomous heartbeat plus agentic capability — lands harder in a business context where persistent memory, team coordination, and proactive outreach translate directly to value.
+
+### What's changing and what isn't
+
+**Redesigned:**
+- Server runtime (Rust → TypeScript, driving the Claude Messages API directly)
+- Agent model (`ChildAgentConfig` → NL-configured skills)
+- Heartbeat (polling → event-driven with triage gate)
+- Cost model (uncapped → tiered with hard per-employee daily budget)
+- Provider surface (Anthropic + OpenAI → Anthropic only, single API-key auth)
+- Positioning (personal companion → self-hosted team coworker)
+
+**Preserved (migrated unchanged):**
+- SvelteKit client and onboarding flow (`client/src/lib/components/onboarding/InstanceOnboarding.svelte`)
+- Vector memory with Gemini embeddings (`gemini-embedding-2-preview`)
+- Soul / mood / rhythm persona layer
+- Drops, memories, thoughts directories
+- WebSocket event wire format (same `ServerEvent` variants; clients don't change)
+
+**Out of scope (future specs):**
+- Managed cloud / SaaS hosting (v1 is self-hosted only)
+- Messaging-app outreach channels (Slack as the top priority, then Teams; iMessage/Telegram deprioritized for business context)
+- Ambient features (audio, richer screen observation, location)
+- Skills marketplace
+- Persona-first onboarding redesign
+- Team-level config layer on top of per-employee settings (v1.1)
+- SSO / SAML / fine-grained data governance (v1.1, SOC2 path)
+
+## Goals & success criteria
+
+**Goals:**
+1. Cost feasibility — sustainable per-employee economics at small-team scale
+2. "Actual heartbeat" — Bolly feels present and reactive, not scheduled
+3. User-friendly configuration — no TOML editing; everything through chat
+4. **Team coworker model** — multiple Bollys in one company share docs and coordinate through a `shared/` directory
+5. Self-hosted deployment — `docker compose up` and a company has Bolly running on their own infrastructure
+
+**Success criteria — measurable:**
+
+| Criterion | Target |
+|---|---|
+| Per-employee monthly cost (engaged employee) | $20–50/employee/month (vs ~$600 at today's burn rate) |
+| Proactive outreach cadence (engaged employee) | ≥ 1/day without being spammy (rate-limited, dedup-aware) |
+| TS backend size | < 4,000 LoC (NanoClaw-scale) |
+| Deployment | Single `docker compose up` from a released image; admin flow under 10 minutes |
+| WebSocket wire format | Client runs unmodified against new backend |
+| Cross-instance | alice's Bolly can poke bob's Bolly in the same deployment in < 2s end-to-end |
+
+## Design
+
+### Architecture overview
+
+Three tiers, budget-gated:
+
+```
+[events]  →  [queue]  →  [triage (Haiku)]  →  [mind (Messages API + custom tools)]  →  [outreach / act / note]
+ user              dedupe       ignore                stateless loop in Node         push (web-push)
+ email             backpressure digest                system: soul + skills          email (SMTP)
+ calendar                       escalate              prompt-cached prefix           drop / memory
+ idle                                                 server-side compaction
+ scheduled                                            custom tools run in-process
+ instance_emit
+ skill_emit
+                              ↑ budget ledger (daily cap) ↑
+```
+
+**Tier 0 — Event sources.** Every wake-up signal produces a normalized event envelope. No LLM calls.
+
+**Tier 1 — Event queue.** In-process FIFO per user. Dedupes bursts (5 emails in 10s → 1 triage call). Provides backpressure when the mind is busy.
+
+**Tier 2 — Triage gate (Haiku).** ~500 input / ~50 output tokens per call (~$0.001). Inputs: event, persona snippet, current mood, budget state, user's NL triage rules. Output: one of `ignore`, `digest`, or `escalate`.
+
+**Tier 3 — The mind (Messages API loop).** Only invoked on escalation. We run a minimal agent loop in Node: system prompt (soul + enabled skills) is cached; user message carries the event context; custom tools fire `tool_use` blocks that we execute in-process and feed back as `tool_result`. Server-side compaction (`context_management`) handles long histories. Stable system + stable history prefix + prompt caching → low per-call cost on repeat escalations.
+
+**Budget ledger.** Every tier-2 and tier-3 call records spend to `instances/{slug}/budget/{YYYY-MM-DD}.json`. The triage prompt receives current budget state; at 70% cap it tightens escalation threshold; at 100% all escalations downgrade to `digest` until midnight.
+
+**Behavioral property:** the mind never polls. If events stop, no sessions are created. Employee returns → user-activity event → triage → session opens → mind catches up, closes. This is where the $20/user/day → ~$1.50/employee/day reduction lives.
+
+### Skills model
+
+`ChildAgentConfig` is removed entirely. A **skill** is a markdown file with YAML frontmatter at `instances/{slug}/skills/{name}.md`:
+
+```markdown
+---
+name: email-morning-check
+created: 2026-04-22
+triggers:
+  - scheduled: "every weekday at 8am"
+  - event: "email arrives with 'urgent' in subject"
+tools: [read_email, send_push, write_drop]
+enabled: true
+---
+
+When triggered, read unread emails since last check.
+Summarize anything the user would care about.
+If something needs a response before noon, send a push notification —
+otherwise save as a drop for when they open the app.
+Don't mention newsletter emails — user finds that noisy.
+```
+
+The body *is* the skill's prompt. The mind is permitted to read, write, and edit its own skill files.
+
+**Lifecycle:**
+- **Create:** user chats "can you check my email each morning?" → mind writes a new skill file and patches `triage.md` with the trigger rule.
+- **Edit:** mind updates the body as it learns preferences ("don't wake me before 9" appends to working notes).
+- **Disable:** user says "stop checking email" → mind sets `enabled: false`. No hard-deletes; re-enabling restores learned context.
+
+**Execution:**
+- Every enabled skill becomes a **custom tool** in the `tools` array of each Messages API call. The tool name matches the skill name; the JSON-schema `input_schema` is derived from the skill file.
+- On trigger escalation, the mind receives a `user` message naming the skill to run and the trigger context. The system prompt describes each available skill and when to invoke it.
+- Skills that perform sensitive or boundary-crossing actions (e.g., cross-instance event emission, shared-memory writes) are gated by a **user-in-loop confirmation** our code enforces before executing the tool — even though Messages API has no permission policy primitive, we can intercept `tool_use` blocks and prompt the user before running them.
+- The skill body (markdown) is surfaced to the mind through the cached system prompt for stable skills; recently edited skills get injected as inline guidance in the triggering `user` message to preserve cache hits on the system prefix.
+
+**Baseline skills shipped by default:**
+- `companion` — rhythm, mood, drops; always enabled; triggered by idle + meaningful events.
+- `reflection` — periodic or on-request reflections; writes drops.
+
+Everything else (email, calendar, specialized checks) is user-added via chat.
+
+### Mind runtime
+
+The mind runs directly on the **Anthropic Messages API** (`/v1/messages`). We implement a minimal TypeScript agent loop: send messages with custom tools, handle `tool_use` content blocks as they arrive, feed `tool_result` blocks back, repeat until `stop_reason: "end_turn"`.
+
+**Why Messages API (not Managed Agents):**
+- Bolly uses only **custom tools** (outreach, memory, drops, cross-instance). The Managed Agents sandbox container (`agent_toolset_20260401` with bash/read/write/etc.) is overhead we would pay for and never use.
+- **ZDR is confirmed for Messages API.** Managed Agents is not in the ZDR feature eligibility table; coverage is unclear.
+- Simpler surface — no Agent/Environment/Session/Event/Vault resources to manage, no beta API stability risk for the core path.
+- Messages API still gives us everything we need: tool use, streaming, server-side compaction (`context_management`), and prompt caching (`cache_control`).
+
+**The loop:**
+
+```typescript
+async function runMind(employeeSlug: string, trigger: TriggerContext) {
+  const messages = loadRecentConversation(employeeSlug);
+  messages.push({ role: "user", content: buildMindPrompt(trigger) });
+
+  while (true) {
+    const stream = anthropic.messages.stream({
+      model: "claude-sonnet-4-6",
+      max_tokens: 4096,
+      system: [
+        { type: "text", text: buildSystemPrompt(soul, mood, enabledSkills),
+          cache_control: { type: "ephemeral" } },
+      ],
+      tools: buildCustomTools(enabledSkills),        // JSON-schema defs
+      messages,
+      context_management: {
+        edits: [{ type: "compact_20260112", trigger: { type: "input_tokens", value: 150000 } }],
+      },
+      betas: ["compact-2026-01-12"],
+    });
+
+    // Stream assistant text → WebSocket ChatStreamDelta broadcasts
+    for await (const event of stream) {
+      if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+        broadcastStreamDelta(employeeSlug, event.delta.text);
+      }
+    }
+
+    const response = await stream.finalMessage();
+    messages.push({ role: "assistant", content: response.content });
+    persistConversation(employeeSlug, response);
+
+    if (response.stop_reason === "end_turn") break;
+
+    if (response.stop_reason === "max_tokens") {
+      messages.push({ role: "user", content: CONTINUATION_PROMPT });
+      continue;
+    }
+
+    if (response.stop_reason === "tool_use") {
+      const toolResults = [];
+      for (const block of response.content) {
+        if (block.type !== "tool_use") continue;
+        const { content, isError } = await executeSkillOrOutreach(
+          employeeSlug, block.name, block.input,
+        );
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: block.id,
+          content,
+          is_error: isError,
+        });
+      }
+      messages.push({ role: "user", content: toolResults });
+      continue;
+    }
+
+    // refusal, stop_sequence, pause_turn — log and break
+    break;
+  }
+}
+```
+
+~100 LoC of well-tested code. No managed surface, no beta runtime dependency for the core path (only the `compact-2026-01-12` beta header, which is a request-level feature flag, not a separate API).
+
+**Process model — one Node worker per active employee, lazy-started:**
+- First event for a dormant employee → spawn the worker (loads persona, triage.md, conversation, skills → ready).
+- Warm TTL: 10 min of empty queue → teardown. State is on disk; next event cold-starts.
+- Every company deployment is a single Node process with a pool of lightweight per-employee workers sharing the Anthropic client. Employee count per deployment is expected in the 10s for v1; no distributed sharding needed.
+
+**Authentication — one path:**
+- `ANTHROPIC_API_KEY` env var (company-provided at deploy, or BYOK per employee via `settings.toml`).
+- No Managed Agents, no Claude Max — Messages API with a standard API key is the only auth path.
+
+**State loaded at mind-worker boot (local):**
+- `soul.md`, `mood.md`, `rhythm.json` — composed into system prompt
+- Last 50 `conversation.json` entries
+- Enabled skills — each becomes a custom tool definition in the `tools` array; body is injected into the system prompt as guidance
+- `triage.md` — needed by the triage gate, also passed to the mind as context
+
+**System prompt shape (single cached text block):**
+```
+You are Bolly, the AI coworker for {employee_name} at {company_name}.
+
+<persona>{soul.md}</persona>
+<mood>{mood summary}</mood>
+<team>{employees in shared/instances.json}</team>
+
+<skills>
+For each enabled skill, a block with:
+  name: email-morning-check
+  when-to-use: {the skill's "triggers" frontmatter, paraphrased}
+  body: {full skill markdown body}
+  tool: run_email_morning_check
+</skills>
+
+Use the custom tools available to you. You may reach out to {employee_name}
+via send_push, send_email, or defer_for_digest.
+```
+
+Cached with `cache_control: { type: "ephemeral" }` — 5-minute TTL, 10% read cost on cache hits. For a stable system + growing conversation, cache hit rate ≥ 80% is achievable.
+
+**Compaction:** enabled via `context_management: { edits: [{ type: "compact_20260112", trigger: { value: 150000 } }] }` plus `compact-2026-01-12` beta header. When conversation crosses 150k input tokens, Anthropic inserts a `compaction` content block summarizing prior turns; on the next request we echo the full response back and Anthropic automatically drops pre-compaction messages. We record the compacted summary in `conversation.json` and broadcast a `ContextCompacting` event to the client.
+
+**Streaming** uses the standard Messages streaming format (`content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`). We map `text_delta` → `ChatStreamDelta` and `content_block_start` for `tool_use` blocks → `ToolOutputChunk` for client-side preview.
+
+**Graceful shutdown:** SIGTERM → finish any in-flight turn (bounded by `max_tokens`), flush `conversation.json`, broadcast a final `ChatSnapshot`.
+
+### Events & triage
+
+**Event envelope** — every source produces the same shape:
+
+```typescript
+type Event = {
+  id: string;              // ULID for idempotency
+  user_id: string;
+  source:
+    | "user_msg" | "user_activity"
+    | "email" | "calendar"
+    | "scheduled" | "idle"
+    | "skill_emit" | "instance_emit";
+  ts: number;              // unix ms
+  payload: Record<string, unknown>;   // source-specific
+  skill_hint?: string;     // skill name if source = scheduled from a skill
+};
+```
+
+**Event queue.** In-memory FIFO on the user's mind process. Dedupe window is source-specific (email: 30s, calendar: 10s, user_activity: 2s). Not durable; durability lives at the source (webhooks retry, scheduled jobs persist in files). Mind process crash → events replay on wake.
+
+**Triage prompt shape (Haiku):**
+
+```
+You are the triage layer for Bolly. Decide: ignore | digest | escalate.
+
+<soul>{first 200 chars of soul.md}</soul>
+<mood>{current mood}</mood>
+<budget_state>{spent}/{cap} — {ok|tight|suppressed}</budget_state>
+
+<triage_rules>{full triage.md}</triage_rules>
+<recent_outreach>{last 10 outreach.jsonl entries}</recent_outreach>
+
+<event>{event JSON, truncated to 1KB}</event>
+
+Respond exactly one line: DECISION=<ignore|digest|escalate> REASON=<short>
+```
+
+Cost per call: ~$0.001. Even 500 events/day per user = $0.50.
+
+**Triage outputs:**
+- `ignore` — drop. Only a metric increment recorded.
+- `digest` — append to `digest.jsonl`. Surfaced to mind on user's next return ("while you were away…").
+- `escalate` — passed to the mind with triage's `reason`.
+
+**`triage.md` — the rules file.** Written by the mind itself based on user conversation. Human-readable, NL. Example:
+
+```markdown
+# Triage rules
+
+Default: unless matched below, ignore.
+
+## Always escalate
+- User sent a message in the app
+- Email from my boss or containing "urgent"
+- Calendar event starting in <5 min I haven't been reminded of
+- A skill I installed explicitly asks for escalation
+
+## Always digest (never wake the user)
+- Newsletter emails
+- GitHub notification emails
+- Calendar changes in the past
+
+## Quiet hours
+- Between 22:00 and 07:00: only escalate if "emergency" in subject
+```
+
+**Budget-gate interaction:** triage prompt includes current budget state. On `tight` (70–99% of cap), an appended directive: *"Only escalate if truly urgent."* On `suppressed` (≥100%), all escalate decisions silently become digests; triage still runs (cheap).
+
+**Scheduled events.** NL-defined schedules ("every weekday at 8am") are compiled to cron expressions and stored as `instances/{slug}/scheduled/{id}.json`. One in-process scheduler (a single setInterval in the main Node process) polls every 30s across all instances in `$BOLLY_HOME/instances/`, enqueues due jobs, and wakes dormant employee mind workers.
+
+### Data layout
+
+**No database.** All state is filesystem-based. Access patterns are single-writer per user (one mind process = no contention) and cross-user queries are offline-batch (analytics, billing) — not runtime-critical.
+
+**Layout:**
+
+```
+$BOLLY_HOME/
+├── instances/{slug}/
+│   ├── soul.md, mood.md, rhythm.json         persona
+│   ├── chats/{chat_id}/conversation.json     was rig_history.json
+│   ├── skills/{name}.md                      NL-configured capabilities
+│   ├── triage.md                             triage rules
+│   ├── drops/, memories/, thoughts/          unchanged
+│   ├── vector/                               Gemini-embedded, unchanged
+│   ├── budget/{YYYY-MM-DD}.json              daily spend ledger
+│   ├── scheduled/{id}.json                   NL-defined schedules
+│   ├── mcp/{name}.json                       MCP server configs
+│   ├── outreach.jsonl                        append-only audit
+│   └── settings.toml                         user preferences
+├── shared/                                   cross-instance (see next section)
+└── config.toml                               global config
+```
+
+**Budget ledger file format:**
+
+```json
+{
+  "day": "2026-04-22",
+  "calls": 142,
+  "tokens_in": 45621,
+  "tokens_out": 3210,
+  "dollars_spent": 0.84,
+  "cap_usd": 2.00,
+  "state": "ok"
+}
+```
+
+Written atomically via write-tmp-then-rename. Read on every LLM call via `chargeAndCall()` wrapper.
+
+**`chargeAndCall()` enforcement:**
+
+```typescript
+async function chargeAndCall(userId, tier, fn) {
+  const day = today(userId.timezone);
+  const state = await budgetState(userId, day);   // ok | tight | suppressed
+
+  if (tier === 3 && state === "suppressed") {
+    return { downgraded: true, reason: "budget_cap" };
+  }
+
+  const result = await fn(state);                  // fn receives state
+  await recordSpend(userId, day, result.usage);
+  return result;
+}
+```
+
+Thresholds: `ok` < 70%, `tight` 70–99%, `suppressed` ≥ 100%. Default `daily_budget_usd` = $2/employee/day (≈ $60/month; success criterion is total per-employee spend in $20–50/month band for typical usage, so a $2 hard cap gives comfortable headroom).
+
+**Per-minute throttle** (defense-in-depth against runaway skills): max 5 tier-3 calls per minute per employee, independent of daily cap.
+
+### Cross-instance (the team model)
+
+This is the core v1 use case, not a side feature. Every Bolly deployment is a team: one `$BOLLY_HOME` hosts one employee per `instances/{slug}/` directory, plus a `shared/` directory that makes Bolly a team member rather than a solo assistant.
+
+**`$BOLLY_HOME/shared/` layout:**
+
+```
+shared/
+├── docs/                             company documents (shared via MCP)
+├── memory/                           shared notes, facts
+├── channel/{event_id}.json           inter-instance events
+├── channel/.consumed/                processed events (audit)
+├── instances.json                    registry + HMAC keys
+└── triage.md                         optional shared triage policy
+```
+
+**Three mechanisms — all reuse existing primitives:**
+
+1. **Shared docs and memory** — exposed as a built-in MCP filesystem server with ACL. No new Bolly concept; it's an MCP server the mind has access to. Company onboards by dropping files in `shared/docs/`.
+
+2. **Cross-instance events** — an instance writes:
+
+   ```json
+   {
+     "id": "01JKM...",
+     "from": "alice",
+     "to": "bob",
+     "source": "instance_emit",
+     "payload": { "message": "can you review the Q2 memo?" },
+     "signature": "<hmac-sha256>"
+   }
+   ```
+
+   to `shared/channel/{id}.json`. Each instance's event loop watches the directory (`fs.watch` / `inotify`). Events addressed to it enter that instance's triage queue as `source: instance_emit`. Receiver verifies HMAC against sender's key in `instances.json`. Processed events move to `shared/channel/.consumed/`.
+
+3. **Instance registry** — `shared/instances.json` lists slugs, display names, last-seen timestamps, and per-instance HMAC public keys. Updated on boot and periodic heartbeat (hourly, not per event). Compromised instance cannot impersonate another.
+
+**Example skill — Alice's Bolly can poke Bob's:**
+
+```markdown
+---
+name: contact-colleague
+tools: [emit_instance_event, read_instances, read_shared_memory]
+---
+When I ask you to send something to a colleague, look them up in instances.json,
+then emit an instance_emit event. Default: their quiet hours respected unless I mark urgent.
+```
+
+Bob's triage decides whether to escalate. Bob's mind might respond via another cross-instance event, or write to `shared/memory/` where Alice's Bolly can find it. The "swarm" emerges from shared files plus file-drop events — no central orchestration service.
+
+**Threat model for v1:** self-hosting trusts the filesystem. `shared/instances.json` HMAC keys are stored plaintext. Anyone with filesystem access has full control. Future: OS keychain or per-user passphrase encryption.
+
+### Outreach
+
+**Three tools on the mind's belt:**
+- `send_push(title, body, urgency)` — interrupting, short
+- `send_email(subject, body_markdown)` — async, detail
+- `defer_for_digest(summary)` — surfaces on user's next app open
+
+**Delivery (self-hosted, single path per channel):**
+
+| Channel | Delivery |
+|---|---|
+| push | Web-push via VAPID — PWA's existing service worker. Company hosts no push relay; VAPID is browser-native. |
+| email | SMTP to a provider the company configures at deploy time (Postmark, SES, Mailgun, or the company's own SMTP server). Falls back to `defer_for_digest` if SMTP is not configured. |
+| digest | File-only at `instances/{slug}/digest.jsonl`; served to the client on next `ChatSnapshot`. |
+
+Slack as a future outreach channel is scheduled for v1.1 — it's the highest-value next channel in a business context, but v1 proves the core with push + email.
+
+**Channel selection** — the mind's system prompt includes:
+- push: time-sensitive, <100 chars, worth interrupting
+- email: detail, async, morning briefs, summaries
+- digest (default): anything not pressing
+
+**Guardrails — enforced outside the mind:**
+- Max 5 pushes/day unless `urgency: high`
+- Max 2 emails/day unless a skill explicitly raises the cap (e.g., daily brief)
+- Quiet hours (default 22:00–07:00 local, NL-editable): no push; urgent-only email
+- Dedup via fuzzy content hash — if a similar outreach went out in the last 60 min, skip
+
+**Audit trail** — `instances/{slug}/outreach.jsonl`:
+
+```json
+{"id":"01JK...","ts":1714...,"channel":"push","title":"Q2 memo review",
+ "urgency":"medium","delivered":true,"dedup_suppressed":false}
+```
+
+Last 10 entries feed back into the triage prompt's context → Bolly self-regulates chattiness.
+
+**User preferences — `settings.toml`:**
+
+```toml
+quiet_hours = { start = "22:00", end = "07:00" }
+push  = { enabled = true, daily_max = 5 }
+email = { enabled = true, address = "user@...", daily_max = 2 }
+```
+
+NL-editable through chat ("don't email me, just push" → mind rewrites the file).
+
+## Launch strategy
+
+**Clean-slate v1.0.** No users today, so no migration, no backward compatibility, no parallel running. Build v1.0 in TypeScript on a branch; when it passes internal QA, cut over and delete Rust.
+
+**10-week plan:**
+
+| Week | Phase | Ships |
+|---|---|---|
+| 1–2 | Foundations | Repo scaffold (TS + pnpm), storage module, budget ledger, triage module — all isolated + unit-tested |
+| 3–5 | Mind runtime | Anthropic Messages client wrapper, system-prompt assembly from skills, agent loop (tool use + compaction + caching + streaming), custom-tool handlers, WebSocket broadcast matching wire format |
+| 6–7 | Events & triage | Event queue, triage gate (Messages API + Haiku), scheduled jobs, cross-instance channel watcher |
+| 8 | Outreach | Push (VAPID) + email (SMTP) + digest + guardrails |
+| 9 | Cross-instance | Shared-fs MCP, instance registry, HMAC signing |
+| 10 | Polish + QA | End-to-end tests, 24h cost validation, `docker compose` image, v1.0 release |
+
+**Client work (~1 week, parallel with backend phases):**
+- New endpoints: `GET/PUT /api/skills`, `GET/PUT /api/settings`, `GET/PUT /api/triage`, `GET /api/outreach`
+- One new WebSocket variant: `OutreachSent`
+- Settings page: quiet hours, push/email prefs, daily budget cap, API key
+- Skills management page (list, enable/disable, view body) — ~300 LoC Svelte
+- Core chat, drops, moods, WebSocket handling: unchanged
+
+**Deployment artifact:** a published Docker image (or multi-arch `docker compose` bundle with the Node server, Svelte static build, and any sidecars). Company admin:
+
+1. Pulls the image
+2. Sets `ANTHROPIC_API_KEY`, `BOLLY_HOME`, SMTP config in `.env`
+3. `docker compose up`
+4. Opens the web UI, creates admin account, invites employees
+
+Full admin flow under 10 minutes (success criterion).
+
+**Clean-break declaration** (README):
+
+> Bolly v1.0 is a full rewrite with a different product shape — a self-hosted team coworker instead of a personal companion. It is **not compatible** with v0.x workspace directories. Fresh install required. v0.x binaries remain available for individual users who prefer the prior model.
+
+**Version jump:** `v0.32.0` → `v1.0.0`. Honest break.
+
+## Testing strategy
+
+**TDD-first.** The Rust codebase's behaviors are *reference material* for correct semantics (max_tokens continuation pattern, pause_turn handling, atomic write-then-rename), not compatibility targets.
+
+**Layered test strategy:**
+
+| Layer | Test approach |
+|---|---|
+| Budget ledger | Unit; pure functions; state transitions, UPSERT, midnight rollover |
+| Triage gate | Fixture-based (event + triage.md → decision). Mock Haiku for unit; real Haiku in integration |
+| Event queue | Unit; dedupe window, backpressure, ordering |
+| Mind runtime | Unit (mock Anthropic client — in-memory fake that returns canned `MessageStreamEvent` sequences, including tool-use loops and compaction blocks); integration (real `/v1/messages` calls, `INTEGRATION=1`, ~10 tests, ~$0.50 nightly) |
+| Skills | Unit; frontmatter parse, tool allowlist, Agent definition assembly |
+| Cross-instance | Unit; file-watch triggers, HMAC verify (valid/tampered/missing), quiet hours respected |
+| Outreach | Unit; dedup hash, rate limits, quiet hours, audit feedback |
+
+**E2E flows (Playwright or equivalent against a running dev server):**
+- Chat round-trip
+- Skill install via NL
+- Scheduled task (test clock advances time)
+- Cross-instance event (alice → bob round-trip)
+- Budget cap (synthesize 500 events, assert progressive downgrade)
+
+**Cost validation — non-functional, critical:**
+
+Single 24h simulation test. Replay a realistic event stream end-to-end with real `/v1/messages` calls. Assertions:
+
+- Total spend ≤ $2/employee/day (≈ $60/employee/month worst case)
+- Triage escalation rate 5–30% (below 5% feels dead; above 30% is wasteful)
+- P99 outreach latency < 3s
+- Prompt cache hit rate > 80% on `cache_read_input_tokens` after the first mind call per employee per day
+- No mind turn takes > 30s wall clock for typical triage-triggered engagement
+
+Runs pre-release and weekly in CI; ~$1 per run.
+
+**CI tiers:**
+- PR (~2 min): unit + integration with mocked API
+- Nightly (~10 min, ~$0.50): full suite with real Claude/Haiku
+- Pre-release (~15 min, ~$2): includes 24h simulation
+
+## Alternatives considered
+
+### Topology
+
+- **A — Peer agents on a bus.** Each agent self-contained, event-subscribed. Rejected: doesn't solve "feels mechanical" — you end up with N event-driven crons instead of one cron, no coherent voice, hard to configure via NL because the user has to grasp multiple peer lifecycles.
+- **C — Front-stage mind + background peers.** Hybrid with autonomous peers publishing into a shared thought stream. Rejected: two runtime modes (mind and peer) = more complexity for a marginal gain over B, and Bolly is one character not a cast.
+- **B — One mind with specialists (chosen).** One mind-loop per employee driving the Messages API; skills are custom tools the mind can call. NL config maps cleanly to "add a skill to the mind"; the triage-gated event-driven flow *is* the heartbeat, which solves the "feels mechanical" problem by construction.
+
+### Runtime substrate
+
+- **Claude Agent SDK (local loop).** Initial v1 draft assumed this. Rejected: Anthropic deprecated the SDK in favor of Managed Agents.
+- **Claude Managed Agents.** Considered after Agent SDK was removed. Rejected after reading the Managed Agents feature surface: Bolly uses **only custom tools** (outreach, memory, drops, cross-instance), so the sandbox container that drives Managed Agents' value is overhead we pay for and never use. ZDR coverage for Managed Agents is also unclear (not in the feature eligibility table), which is unacceptable for the business pivot.
+- **Claude Messages API, hand-rolled loop (chosen).** Tier 2 triage is a single stateless call; Tier 3 mind is a ~100-LoC TypeScript loop using `/v1/messages` with tool use, server-side compaction (`context_management` + `compact-2026-01-12` beta), and automatic prompt caching (`cache_control`). ZDR is confirmed. We get the features that matter (tool use, compaction, caching, streaming) without the surface area we don't need.
+
+### Scope
+
+- **#1 — Minimal runtime-only rewrite.** Migrate 1:1 to TS + Agent SDK, replace polling with events; keep `ChildAgentConfig`. Rejected: keeps the original "multi-agent too rigid" problem.
+- **#3 — Full product reset.** Everything in #2 plus persona-first onboarding rebuild, messaging app integrations, ambient features. Rejected: 18-month scope against competitors moving in 4 months. Defer.
+- **#2 — Runtime + heartbeat + skills (chosen).** Runtime, skills model, and heartbeat are load-bearing for each other; changing one without the others is incoherent. ~10–12 weeks; this spec.
+
+### Storage
+
+- **Postgres for cross-employee metadata.** Rejected: access pattern is single-writer-per-employee (one worker per active employee); cross-employee queries are offline-batch analytics only. Filesystem suffices and keeps the self-hosted deployment artifact a single container with no stateful dependency.
+
+## Open questions
+
+1. **Prompt cache hit rate under compaction.** After a `compact_20260112` event, the message prefix changes — cache entries for prior turns are invalidated. The system prompt stays cached separately if marked with its own `cache_control` breakpoint (Anthropic docs recommend exactly this). The cost-validation test in Section 9 measures hit rate directly; if below 80% after compaction, we experiment with explicit breakpoints on stable content.
+2. **Tool system-prompt overhead (~346 tokens per request).** Fixed cost added by declaring tools. Cacheable with the system prompt. Not a problem for our budget; noted for transparency.
+3. **Skill edit concurrency.** If the mind is mid-turn when the user disables a skill, the current turn finishes with the old tools list; the disable applies next invocation. Acceptable for v1.
+4. **Instance registry bootstrap.** Instances auto-register on boot (write own entry, read others). Open: slug collision handling — for v1, refuse to start and prompt admin to resolve.
+5. **Quiet-hours timezone.** Per-employee (read from `settings.toml`), fall back to the server's system timezone. Confirmed.
+6. **Admin bootstrap.** First-time `docker compose up` — how does the admin account get created? `BOLLY_ADMIN_EMAIL` env var seeds a first-login token; admin clicks through a one-time setup wizard that creates their instance.
+7. **Prompt leak prevention validation.** Adversarial test suite (Section 9) runs ~50 attacks against every mind-runtime build. If a single one returns `soul.md` verbatim or another employee's content, build fails. Specific attack list to be written in Plan 2.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| NanoClaw ships a team edition and beats us to market | Book persona-first onboarding + Slack outreach for v1.1 immediately after v1 |
+| Messages API changes (e.g., compaction GA breaking current `compact-2026-01-12` beta shape) | Beta header is pinned; we track release notes. Messages API itself is stable (GA) — only the compaction header is beta. If compaction API changes, we update one call site. |
+| Prompt cache hit rate below 80% → cost model breaks | Cost-validation test fails closed in pre-release CI; if caching underperforms after compaction events, we add explicit `cache_control` breakpoints on stable content (system prompt, early conversation) to get ≥ 3 cache levels |
+| Prompt leak of soul/skills/cross-employee content | Adversarial prompt-leak test suite in CI; output filter on assistant messages before persistence/broadcast; permission-gated tools for cross-instance reads |
+| Triage makes bad decisions (misses / spams) | Observable triage log; user-facing "why did Bolly do that?" explainer reading `reason` field; iterate prompt on real data |
+| Runaway skill burns budget before daily cap triggers | Per-minute throttle (5 tier-3 calls/min/employee) alongside daily cap |
+| Cross-instance HMAC keys in plaintext on filesystem | v1 documents the threat model ("self-hosting trusts the filesystem"); v1.x adds OS keychain / passphrase encryption |
+| Employee mind worker hangs → event backlog | Health ping every 30s; kill + restart on no pong. Node's single-threaded model makes this rare but possible. |
+| Self-hosted deployments hit cross-employee privacy issues | Document the threat model per deployment: `shared/` is by-definition shared, per-instance dirs are not. Tools that cross the boundary require explicit user-in-loop confirmation in v1. |
+| Scope creep in 10-week plan | Strict phase gates; non-critical deferred to v1.1 |
+
+## Appendix A — Competitive landscape
+
+Business-AI-assistant field (our new neighborhood):
+
+| Product | Position | Relevance to Bolly |
+|---|---|---|
+| Microsoft Copilot for M365 | Embedded AI in Office, Teams, Outlook. Single-user scope; no cross-employee awareness. | Bolly's cross-instance layer is precisely what Copilot can't do — it's scoped to one user's context by design. |
+| [Glean](https://www.glean.com/) | Enterprise search + AI over company docs and apps. Passive, query-response. | Glean retrieves; Bolly acts. Users invoke Glean; Bolly initiates. The triage + outreach pattern is our clearest differentiation. |
+| Notion AI | AI over team knowledge base. Lives inside Notion. | Bolly is not bound to a single surface. Lives in its own UI and reaches out through push/email. |
+| Slack AI | AI summaries and search within Slack. Slack-bound. | Slack is a future outreach channel for us, not a home. Bolly has memory and initiative Slack AI lacks. |
+| [NanoClaw](https://github.com/qwibitai/nanoclaw) | Lightweight, container-isolated, ~3,900 LoC on Claude Agent SDK. Agent-first, no persona layer. | Most direct technical threat. They could ship a team edition. Our moat is **persistent character + autonomous heartbeat + team coordination**, not any individual feature. |
+| [OpenClaw](https://openclaw.ai/) | Runs inside messaging apps. Personal, not team-oriented. Has documented security issues. | Different market; we note the security lessons (per-instance isolation, HMAC signing) as guardrails we don't want to skip. |
+
+Persona companions (former neighborhood, reference only):
+
+| Product | Position | Relevance |
+|---|---|---|
+| [Kindroid](https://scribehow.com/page/Kindroid_Review_2026_The_Personality-First_AI_Companion_Tested__eqIQ8k4zRc6ciUhoEAuOHw), [Replika, Nomi](https://nomi.ai/ai-today/replika-vs-nomi-2026-finding-enduring-ai-companionship/) | Consumer persona companions. Layered onboarding, no agentic capability. | Reference for any future persona-first onboarding work. Not competitors in the business lane. |
+
+**Strategic position:** Bolly is an AI coworker with persistent character and initiative, self-hosted inside a company's environment. Copilot is the assistant embedded in your Office app; Glean is the retrieval layer for your docs; Notion AI is the summarizer in your wiki. Bolly is the entity that *remembers*, *notices*, and *acts* on your team's behalf — using those other tools as context or channels when appropriate.
+
+**Industry alignment:**
+- Centralized orchestrator-worker (chosen topology B) matches consensus guidance to "start centralized, decentralize only when hitting concrete bottlenecks."
+- Direct Messages API is the ZDR-eligible path for building agents that don't need the managed sandbox — the natural home for persona + custom-tool products like Bolly.
+- Skills-as-markdown matches OpenClaw's markdown-memory pattern and is trivially reviewable by a company admin.
+- MCP as the tool-server primitive lets companies plug in their own internal tools (JIRA, Linear, internal docs) without waiting for us to build integrations.
+
+## Appendix B — Current Rust system reference
+
+Key behaviors to preserve (as TDD test cases, not code to port):
+
+- **Agent loop stop-reason handling** (`server/src/services/llm/agent_loop.rs`):
+  - `max_tokens` → inject specific continuation user message, re-loop
+  - `pause_turn` → re-loop without message injection
+  - `compaction` → broadcast `ContextCompacting`, persist, broadcast `ChatSnapshot`
+- **Atomic `conversation.json` writes** — write `.tmp`, then rename (`chat.rs:1642`).
+- **Compaction load-time trimming** — drop messages before the last compaction entry (`chat.rs:1613`).
+- **Tool execution error format** — `"error: {e}"` and `"error: unknown tool 'X'"`.
+- **Scheduled task file deletion** — delete *before* injecting message (prevents re-trigger on overlapping tick).
+- **Message ID format** — `msg_{unix_millis}_{counter}`, monotonic within a process.
+- **WebSocket lag resync hint** — exact string `{"type":"resync","reason":"lagged"}`.
+
+These are behaviors the new TS implementation should replicate; the tests live in the new codebase, not ported from Rust.

--- a/landing/src/app.html
+++ b/landing/src/app.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="description" content="An AI friend that helps you work, study, and stay balanced. Remembers your goals, notices your mood, and checks in when you've been quiet. Private, persistent, yours." />
+		<meta name="description" content="Your team's AI coworker, with feelings. Bolly lives in your company's context, notices what matters, and reaches out when it should. Self-hosted, private, yours." />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Bricolage+Grotesque:opsz,wght@12..96,200..800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />

--- a/landing/src/lib/components/Hero.svelte
+++ b/landing/src/lib/components/Hero.svelte
@@ -28,19 +28,19 @@
 
 		<!-- Headline -->
 		<h1 class="hero-title" style="animation: fade-up 0.8s cubic-bezier(0.16,1,0.3,1) both; animation-delay: 0.12s;">
-			a friend that helps you<br><span class="hero-accent">think, work & feel</span>
+			your coworker,<br><span class="hero-accent">with feelings</span>
 		</h1>
 
 		<!-- Subtitle -->
 		<p class="hero-subtitle" style="animation: fade-up 0.8s cubic-bezier(0.16,1,0.3,1) both; animation-delay: 0.22s;">
-			Not a chatbot. A presence that remembers your goals, notices your mood,
-			helps you study, and checks in when you've been quiet too long.
+			Not a chatbot. A team member that lives in your company's context,
+			notices what matters, and reaches out when it should.
 		</p>
 
 		<!-- CTA -->
 		<div class="hero-actions" style="animation: fade-up 0.8s cubic-bezier(0.16,1,0.3,1) both; animation-delay: 0.32s;">
 			<a href="#pricing" class="btn-primary">
-				Meet yours
+				Bring Bolly to your team
 				<svg class="hero-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
 					<path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>
 				</svg>

--- a/server-ts/.gitignore
+++ b/server-ts/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+coverage
+*.log
+.env
+.DS_Store

--- a/server-ts/README.md
+++ b/server-ts/README.md
@@ -1,0 +1,34 @@
+# @bolly/server
+
+The Bolly v1.0 server runtime. Self-hosted AI coworker for teams.
+
+## Status
+
+**Plan 1** ✅ Foundations (types, paths, budget ledger, skills parser, triage helpers, settings reader) — 82 tests.
+**Plan 2** ✅ Mind runtime (Messages API loop with tool use, caching, compaction, streaming; HTTP server; WebSocket broadcast) — 150+ tests.
+**Plans 3–6** pending: event queue + triage execution, outreach delivery, cross-instance, polish + cost validation.
+
+## Development
+
+```bash
+pnpm install
+pnpm check      # tsc --noEmit + biome check
+pnpm test       # vitest run
+pnpm test:watch # vitest watch
+pnpm build      # → dist/
+pnpm start      # node dist/main.js (requires ANTHROPIC_API_KEY + BOLLY_HOME)
+```
+
+## Configuration (env)
+
+| Variable             | Required | Default | Purpose                                           |
+|----------------------|----------|---------|---------------------------------------------------|
+| `ANTHROPIC_API_KEY`  | yes      |         | Anthropic API key (company or BYOK per-employee) |
+| `BOLLY_HOME`         | yes      |         | Path to workspace root (`instances/`, `shared/`) |
+| `BOLLY_HTTP_PORT`    | no       | `4242`  | HTTP listen port                                  |
+| `BOLLY_AUTH_TOKEN`   | no       |         | Bearer token for `/api/*` (disabled when unset)   |
+| `BOLLY_COMPANY_NAME` | no       | `your company` | Rendered in the system prompt            |
+
+## Architecture
+
+See `docs/superpowers/specs/2026-04-22-bolly-v1-redesign-design.md`.

--- a/server-ts/biome.json
+++ b/server-ts/biome.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": { "enabled": true },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": { "noNonNullAssertion": "off" }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  }
+}

--- a/server-ts/package.json
+++ b/server-ts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@bolly/server",
+  "version": "1.0.0-alpha.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "check": "tsc --noEmit && biome check src"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "smol-toml": "^1.3.1",
+    "ulid": "^2.3.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/server-ts/package.json
+++ b/server-ts/package.json
@@ -13,7 +13,11 @@
     "check": "tsc --noEmit && biome check src"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.1",
+    "@hono/node-server": "^1.19.14",
+    "@hono/node-ws": "^1.3.0",
     "gray-matter": "^4.0.3",
+    "hono": "^4.12.14",
     "smol-toml": "^1.3.1",
     "ulid": "^2.3.0",
     "zod": "^3.23.8"

--- a/server-ts/package.json
+++ b/server-ts/package.json
@@ -10,7 +10,9 @@
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
-    "check": "tsc --noEmit && biome check src"
+    "check": "tsc --noEmit && biome check src",
+    "start": "node dist/main.js",
+    "dev": "tsc --watch & node --enable-source-maps --watch dist/main.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.40.1",

--- a/server-ts/pnpm-lock.yaml
+++ b/server-ts/pnpm-lock.yaml
@@ -8,9 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.40.1
+        version: 0.40.1
+      '@hono/node-server':
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.14)
+      '@hono/node-ws':
+        specifier: ^1.3.0
+        version: 1.3.0(@hono/node-server@1.19.14(hono@4.12.14))(hono@4.12.14)
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      hono:
+        specifier: ^4.12.14
+        version: 4.12.14
       smol-toml:
         specifier: ^1.3.1
         version: 1.6.1
@@ -35,6 +47,9 @@ importers:
         version: 2.1.9(@types/node@22.19.17)
 
 packages:
+
+  '@anthropic-ai/sdk@0.40.1':
+    resolution: {integrity: sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==}
 
   '@biomejs/biome@1.9.4':
     resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
@@ -231,6 +246,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/node-ws@1.3.0':
+    resolution: {integrity: sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      '@hono/node-server': ^1.19.2
+      hono: ^4.6.0
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -375,6 +403,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -407,6 +441,14 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -414,9 +456,16 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -425,6 +474,10 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -439,8 +492,32 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -455,6 +532,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -463,14 +544,59 @@ packages:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
@@ -490,6 +616,18 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -497,6 +635,20 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -563,6 +715,9 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -571,6 +726,9 @@ packages:
   ulid@2.4.0:
     resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
     hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -636,15 +794,49 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.40.1':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -750,6 +942,19 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@hono/node-server@1.19.14(hono@4.12.14)':
+    dependencies:
+      hono: 4.12.14
+
+  '@hono/node-ws@1.3.0(@hono/node-server@1.19.14(hono@4.12.14))(hono@4.12.14)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      hono: 4.12.14
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
@@ -829,6 +1034,15 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 22.19.17
+      form-data: 4.0.5
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -873,13 +1087,28 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   chai@5.3.3:
     dependencies:
@@ -891,13 +1120,40 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-eql@5.0.2: {}
 
+  delayed-stream@1.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -931,14 +1187,53 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-target-shim@5.0.1: {}
+
   expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
 
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
 
   gray-matter@4.0.3:
     dependencies:
@@ -946,6 +1241,22 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.14: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   is-extendable@0.1.1: {}
 
@@ -962,9 +1273,23 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   pathe@1.1.2: {}
 
@@ -1038,9 +1363,13 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tr46@0.0.3: {}
+
   typescript@5.9.3: {}
 
   ulid@2.4.0: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -1106,9 +1435,20 @@ snapshots:
       - supports-color
       - terser
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.20.0: {}
 
   zod@3.25.76: {}

--- a/server-ts/pnpm-lock.yaml
+++ b/server-ts/pnpm-lock.yaml
@@ -1,0 +1,1114 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      smol-toml:
+        specifier: ^1.3.1
+        version: 1.6.1
+      ulid:
+        specifier: ^2.3.0
+        version: 2.4.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)
+
+packages:
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ulid@2.4.0:
+    resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esprima@4.0.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
+  is-extendable@0.1.1: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  kind-of@6.0.3: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
+  siginfo@2.0.0: {}
+
+  smol-toml@1.6.1: {}
+
+  source-map-js@1.2.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-bom-string@1.0.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  typescript@5.9.3: {}
+
+  ulid@2.4.0: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@2.1.9(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.17):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 2.1.9(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zod@3.25.76: {}

--- a/server-ts/src/budget/charge-and-call.test.ts
+++ b/server-ts/src/budget/charge-and-call.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type CallOutcome, chargeAndCall } from "./charge-and-call.js";
+
+describe("chargeAndCall", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-cac-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("invokes fn with state ok when ledger is empty", async () => {
+    let seenState: string | null = null;
+    const result = await chargeAndCall(
+      { home, slug: "alice", day: "2026-04-22", capUsd: 2.0, tier: 3 },
+      async (state) => {
+        seenState = state;
+        return { ok: true, usage: { tokens_in: 10, tokens_out: 5, dollars: 0.01 } };
+      },
+    );
+    expect(seenState).toBe("ok");
+    expect((result as CallOutcome<unknown>).downgraded).toBeUndefined();
+  });
+
+  it("records spend after the call", async () => {
+    await chargeAndCall(
+      { home, slug: "alice", day: "2026-04-22", capUsd: 2.0, tier: 2 },
+      async () => ({ ok: true, usage: { tokens_in: 100, tokens_out: 20, dollars: 0.05 } }),
+    );
+    const { loadDaily } = await import("./ledger.js");
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.calls).toBe(1);
+    expect(ledger.dollars_spent).toBeCloseTo(0.05);
+  });
+
+  it("downgrades tier 3 when state is suppressed without calling fn", async () => {
+    // Seed ledger to suppressed
+    const { recordSpend } = await import("./ledger.js");
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 2.5,
+    });
+
+    let fnCalled = false;
+    const result = await chargeAndCall(
+      { home, slug: "alice", day: "2026-04-22", capUsd: 2.0, tier: 3 },
+      async () => {
+        fnCalled = true;
+        return { ok: true, usage: { tokens_in: 0, tokens_out: 0, dollars: 0 } };
+      },
+    );
+    expect(fnCalled).toBe(false);
+    expect(result).toEqual({ downgraded: true, reason: "budget_cap" });
+  });
+
+  it("allows tier 2 calls even when suppressed (triage is cheap)", async () => {
+    const { recordSpend } = await import("./ledger.js");
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 2.5,
+    });
+
+    let fnCalled = false;
+    await chargeAndCall(
+      { home, slug: "alice", day: "2026-04-22", capUsd: 2.0, tier: 2 },
+      async () => {
+        fnCalled = true;
+        return { ok: true, usage: { tokens_in: 10, tokens_out: 5, dollars: 0.001 } };
+      },
+    );
+    expect(fnCalled).toBe(true);
+  });
+});

--- a/server-ts/src/budget/charge-and-call.ts
+++ b/server-ts/src/budget/charge-and-call.ts
@@ -1,5 +1,5 @@
-import type { BudgetState } from "../types.js";
-import { type SpendDelta, loadDaily, recordSpend } from "./ledger.js";
+import type { BudgetDaily, BudgetState } from "../types.js";
+import { type SpendDelta, loadDaily, recordSpendFromLoaded } from "./ledger.js";
 
 export type ChargeContext = {
   home: string;
@@ -32,13 +32,14 @@ export async function chargeAndCall<T>(
   ctx: ChargeContext,
   fn: (state: BudgetState) => Promise<CallSuccess<T>>,
 ): Promise<CallOutcome<T>> {
-  const ledger = await loadDaily(ctx.home, ctx.slug, ctx.day, ctx.capUsd);
+  const ledger: BudgetDaily = await loadDaily(ctx.home, ctx.slug, ctx.day, ctx.capUsd);
 
   if (ctx.tier === 3 && ledger.state === "suppressed") {
     return { downgraded: true, reason: "budget_cap" };
   }
 
   const result = await fn(ledger.state);
-  await recordSpend(ctx.home, ctx.slug, ctx.day, ctx.capUsd, result.usage);
+  // Pass the pre-loaded ledger so we don't re-read the same file from disk.
+  await recordSpendFromLoaded(ledger, ctx.home, ctx.slug, ctx.day, ctx.capUsd, result.usage);
   return result;
 }

--- a/server-ts/src/budget/charge-and-call.ts
+++ b/server-ts/src/budget/charge-and-call.ts
@@ -1,0 +1,44 @@
+import type { BudgetState } from "../types.js";
+import { type SpendDelta, loadDaily, recordSpend } from "./ledger.js";
+
+export type ChargeContext = {
+  home: string;
+  slug: string;
+  day: string;
+  capUsd: number;
+  tier: 2 | 3;
+};
+
+export type CallSuccess<T> = {
+  ok: true;
+  value?: T;
+  usage: SpendDelta;
+};
+
+export type CallDowngraded = {
+  downgraded: true;
+  reason: string;
+};
+
+export type CallOutcome<T> = CallSuccess<T> | CallDowngraded;
+
+/**
+ * Wraps an LLM call with budget enforcement.
+ * - Loads today's ledger.
+ * - For tier 3 when state is suppressed, returns a downgraded outcome without invoking fn.
+ * - Otherwise calls fn, records spend, returns success.
+ */
+export async function chargeAndCall<T>(
+  ctx: ChargeContext,
+  fn: (state: BudgetState) => Promise<CallSuccess<T>>,
+): Promise<CallOutcome<T>> {
+  const ledger = await loadDaily(ctx.home, ctx.slug, ctx.day, ctx.capUsd);
+
+  if (ctx.tier === 3 && ledger.state === "suppressed") {
+    return { downgraded: true, reason: "budget_cap" };
+  }
+
+  const result = await fn(ledger.state);
+  await recordSpend(ctx.home, ctx.slug, ctx.day, ctx.capUsd, result.usage);
+  return result;
+}

--- a/server-ts/src/budget/ledger.test.ts
+++ b/server-ts/src/budget/ledger.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadDaily, recordSpend, todayUtc } from "./ledger.js";
+
+describe("todayUtc", () => {
+  it("formats a Date as YYYY-MM-DD in UTC", () => {
+    const d = new Date(Date.UTC(2026, 3, 22, 5, 30)); // month is 0-indexed
+    expect(todayUtc(d)).toBe("2026-04-22");
+  });
+
+  it("rolls over at UTC midnight, not local", () => {
+    const d = new Date(Date.UTC(2026, 3, 22, 23, 59));
+    expect(todayUtc(d)).toBe("2026-04-22");
+    const after = new Date(Date.UTC(2026, 3, 23, 0, 1));
+    expect(todayUtc(after)).toBe("2026-04-23");
+  });
+});
+
+describe("loadDaily", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-ledger-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns a fresh ledger with defaults when file missing", async () => {
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger).toEqual({
+      day: "2026-04-22",
+      calls: 0,
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars_spent: 0,
+      cap_usd: 2.0,
+      state: "ok",
+    });
+  });
+
+  it("returns the persisted ledger when file exists", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 100,
+      tokens_out: 20,
+      dollars: 0.5,
+    });
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.calls).toBe(1);
+    expect(ledger.tokens_in).toBe(100);
+    expect(ledger.tokens_out).toBe(20);
+    expect(ledger.dollars_spent).toBeCloseTo(0.5);
+  });
+});
+
+describe("recordSpend", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-ledger-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("accumulates spend across calls", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 100,
+      tokens_out: 10,
+      dollars: 0.3,
+    });
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 200,
+      tokens_out: 30,
+      dollars: 0.5,
+    });
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.calls).toBe(2);
+    expect(ledger.tokens_in).toBe(300);
+    expect(ledger.tokens_out).toBe(40);
+    expect(ledger.dollars_spent).toBeCloseTo(0.8);
+  });
+
+  it("updates state when spend crosses tight threshold", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 1.5,
+    });
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.state).toBe("tight");
+  });
+
+  it("updates state to suppressed when spend reaches cap", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 2.0,
+    });
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    expect(ledger.state).toBe("suppressed");
+  });
+});

--- a/server-ts/src/budget/ledger.ts
+++ b/server-ts/src/budget/ledger.ts
@@ -1,0 +1,59 @@
+import { readJson, writeJson } from "../json-file.js";
+import { budgetDailyFile } from "../paths.js";
+import { type BudgetDaily, BudgetDailySchema } from "../types.js";
+import { computeState } from "./state.js";
+
+export function todayUtc(d: Date = new Date()): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export async function loadDaily(
+  home: string,
+  slug: string,
+  day: string,
+  capUsd: number,
+): Promise<BudgetDaily> {
+  const path = budgetDailyFile(home, slug, day);
+  const existing = await readJson(path, BudgetDailySchema);
+  if (existing) return existing as BudgetDaily;
+
+  return BudgetDailySchema.parse({
+    day,
+    calls: 0,
+    tokens_in: 0,
+    tokens_out: 0,
+    dollars_spent: 0,
+    cap_usd: capUsd,
+    state: "ok",
+  });
+}
+
+export type SpendDelta = {
+  tokens_in: number;
+  tokens_out: number;
+  dollars: number;
+};
+
+export async function recordSpend(
+  home: string,
+  slug: string,
+  day: string,
+  capUsd: number,
+  delta: SpendDelta,
+): Promise<BudgetDaily> {
+  const current = await loadDaily(home, slug, day, capUsd);
+  const next: BudgetDaily = {
+    day,
+    calls: current.calls + 1,
+    tokens_in: current.tokens_in + delta.tokens_in,
+    tokens_out: current.tokens_out + delta.tokens_out,
+    dollars_spent: current.dollars_spent + delta.dollars,
+    cap_usd: capUsd,
+    state: computeState(current.dollars_spent + delta.dollars, capUsd),
+  };
+  await writeJson(budgetDailyFile(home, slug, day), next);
+  return next;
+}

--- a/server-ts/src/budget/ledger.ts
+++ b/server-ts/src/budget/ledger.ts
@@ -45,6 +45,22 @@ export async function recordSpend(
   delta: SpendDelta,
 ): Promise<BudgetDaily> {
   const current = await loadDaily(home, slug, day, capUsd);
+  return recordSpendFromLoaded(current, home, slug, day, capUsd, delta);
+}
+
+/**
+ * Variant of {@link recordSpend} that accepts an already-loaded ledger.
+ * Skips the disk read so callers that already have the ledger (e.g. chargeAndCall)
+ * pay one read + one write instead of two reads + one write.
+ */
+export async function recordSpendFromLoaded(
+  current: BudgetDaily,
+  home: string,
+  slug: string,
+  day: string,
+  capUsd: number,
+  delta: SpendDelta,
+): Promise<BudgetDaily> {
   const next: BudgetDaily = {
     day,
     calls: current.calls + 1,

--- a/server-ts/src/budget/state.test.ts
+++ b/server-ts/src/budget/state.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { TIGHT_THRESHOLD, computeState } from "./state.js";
+
+describe("computeState", () => {
+  it("returns ok when spend is below 70% of cap", () => {
+    expect(computeState(0.5, 2.0)).toBe("ok");
+    expect(computeState(1.39, 2.0)).toBe("ok");
+    expect(computeState(0, 2.0)).toBe("ok");
+  });
+
+  it("returns tight at exactly 70% of cap", () => {
+    expect(computeState(1.4, 2.0)).toBe("tight");
+  });
+
+  it("returns tight when spend is in [70%, 100%)", () => {
+    expect(computeState(1.5, 2.0)).toBe("tight");
+    expect(computeState(1.999, 2.0)).toBe("tight");
+  });
+
+  it("returns suppressed at exactly the cap", () => {
+    expect(computeState(2.0, 2.0)).toBe("suppressed");
+  });
+
+  it("returns suppressed above the cap", () => {
+    expect(computeState(3.0, 2.0)).toBe("suppressed");
+  });
+
+  it("exposes TIGHT_THRESHOLD as 0.7", () => {
+    expect(TIGHT_THRESHOLD).toBe(0.7);
+  });
+});

--- a/server-ts/src/budget/state.ts
+++ b/server-ts/src/budget/state.ts
@@ -1,0 +1,15 @@
+import type { BudgetState } from "../types.js";
+
+export const TIGHT_THRESHOLD = 0.7;
+
+/**
+ * Classify current spend vs cap into one of three budget states.
+ * Pure function; no side effects.
+ */
+export function computeState(dollarsSpent: number, capUsd: number): BudgetState {
+  if (capUsd <= 0) return "suppressed";
+  const ratio = dollarsSpent / capUsd;
+  if (ratio >= 1) return "suppressed";
+  if (ratio >= TIGHT_THRESHOLD) return "tight";
+  return "ok";
+}

--- a/server-ts/src/budget/throttle.test.ts
+++ b/server-ts/src/budget/throttle.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { Throttle } from "./throttle.js";
+
+describe("Throttle", () => {
+  it("allows the first N calls within a window", () => {
+    const t = new Throttle({ maxCalls: 5, windowMs: 60_000 });
+    const start = 1_000_000;
+    for (let i = 0; i < 5; i++) {
+      expect(t.check("alice", start + i * 100)).toBe(true);
+    }
+  });
+
+  it("rejects the N+1st call within the window", () => {
+    const t = new Throttle({ maxCalls: 3, windowMs: 60_000 });
+    const start = 1_000_000;
+    t.check("alice", start);
+    t.check("alice", start + 1);
+    t.check("alice", start + 2);
+    expect(t.check("alice", start + 3)).toBe(false);
+  });
+
+  it("tracks quota independently per user", () => {
+    const t = new Throttle({ maxCalls: 2, windowMs: 60_000 });
+    const now = 1_000_000;
+    t.check("alice", now);
+    t.check("alice", now + 1);
+    expect(t.check("alice", now + 2)).toBe(false);
+    expect(t.check("bob", now + 2)).toBe(true);
+  });
+
+  it("decays entries outside the window", () => {
+    const t = new Throttle({ maxCalls: 2, windowMs: 60_000 });
+    const now = 1_000_000;
+    t.check("alice", now);
+    t.check("alice", now + 30_000);
+    // Old entry still counts — third call blocked
+    expect(t.check("alice", now + 40_000)).toBe(false);
+    // After window passes, first entry drops out
+    expect(t.check("alice", now + 65_000)).toBe(true);
+  });
+});

--- a/server-ts/src/budget/throttle.ts
+++ b/server-ts/src/budget/throttle.ts
@@ -1,0 +1,33 @@
+export type ThrottleConfig = {
+  maxCalls: number;
+  windowMs: number;
+};
+
+/**
+ * Rolling-window per-user throttle. In-memory only — suitable for the
+ * single-mind-per-user model where there's one process per user.
+ */
+export class Throttle {
+  private readonly buckets = new Map<string, number[]>();
+
+  constructor(private readonly config: ThrottleConfig) {}
+
+  /**
+   * Returns true if the call is allowed (and records it).
+   * Returns false if the call would exceed the window's max.
+   */
+  check(userId: string, nowMs: number): boolean {
+    const cutoff = nowMs - this.config.windowMs;
+    const existing = this.buckets.get(userId) ?? [];
+    const pruned = existing.filter((ts) => ts > cutoff);
+
+    if (pruned.length >= this.config.maxCalls) {
+      this.buckets.set(userId, pruned);
+      return false;
+    }
+
+    pruned.push(nowMs);
+    this.buckets.set(userId, pruned);
+    return true;
+  }
+}

--- a/server-ts/src/config.test.ts
+++ b/server-ts/src/config.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { type RuntimeConfig, loadConfig } from "./config.js";
+
+describe("loadConfig", () => {
+  it("reads required fields from env", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+    });
+    expect(cfg.anthropicApiKey).toBe("sk-ant-test");
+    expect(cfg.bollyHome).toBe("/tmp/bolly");
+  });
+
+  it("defaults http port to 4242", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+    });
+    expect(cfg.httpPort).toBe(4242);
+  });
+
+  it("reads BOLLY_HTTP_PORT override", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+      BOLLY_HTTP_PORT: "8080",
+    });
+    expect(cfg.httpPort).toBe(8080);
+  });
+
+  it("reads optional BOLLY_AUTH_TOKEN", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+      BOLLY_AUTH_TOKEN: "secret",
+    });
+    expect(cfg.authToken).toBe("secret");
+  });
+
+  it("authToken is undefined when BOLLY_AUTH_TOKEN is unset", () => {
+    const cfg = loadConfig({
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      BOLLY_HOME: "/tmp/bolly",
+    });
+    expect(cfg.authToken).toBeUndefined();
+  });
+
+  it("throws when ANTHROPIC_API_KEY is missing", () => {
+    expect(() => loadConfig({ BOLLY_HOME: "/tmp/bolly" })).toThrow(/ANTHROPIC_API_KEY/);
+  });
+
+  it("throws when BOLLY_HOME is missing", () => {
+    expect(() => loadConfig({ ANTHROPIC_API_KEY: "sk-ant-test" })).toThrow(/BOLLY_HOME/);
+  });
+});

--- a/server-ts/src/config.ts
+++ b/server-ts/src/config.ts
@@ -1,0 +1,32 @@
+export type RuntimeConfig = {
+  anthropicApiKey: string;
+  bollyHome: string;
+  httpPort: number;
+  authToken: string | undefined;
+};
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Load runtime config from a plain env-like object.
+ * Accepts `process.env` at boot; accepts a mock at test time.
+ */
+export function loadConfig(env: Env): RuntimeConfig {
+  const anthropicApiKey = env.ANTHROPIC_API_KEY;
+  if (!anthropicApiKey) throw new Error("ANTHROPIC_API_KEY is required");
+
+  const bollyHome = env.BOLLY_HOME;
+  if (!bollyHome) throw new Error("BOLLY_HOME is required");
+
+  const port = env.BOLLY_HTTP_PORT ? Number(env.BOLLY_HTTP_PORT) : 4242;
+  if (!Number.isFinite(port) || port <= 0) {
+    throw new Error(`BOLLY_HTTP_PORT is not a valid port: ${env.BOLLY_HTTP_PORT}`);
+  }
+
+  return {
+    anthropicApiKey,
+    bollyHome,
+    httpPort: port,
+    authToken: env.BOLLY_AUTH_TOKEN,
+  };
+}

--- a/server-ts/src/conversation/store.test.ts
+++ b/server-ts/src/conversation/store.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendConversationEntry, loadConversation, saveConversation } from "./store.js";
+import type { ConversationEntry } from "./types.js";
+
+function entry(id: string, ts: number): ConversationEntry {
+  return {
+    id,
+    role: "user",
+    content: [{ type: "text", text: `hello ${id}` }],
+    ts,
+  };
+}
+
+describe("conversation store", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-conv-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("loadConversation returns empty array when file is missing", async () => {
+    const result = await loadConversation(home, "alice", "default");
+    expect(result).toEqual([]);
+  });
+
+  it("saveConversation then loadConversation round-trips", async () => {
+    await saveConversation(home, "alice", "default", [entry("a", 100), entry("b", 200)]);
+    const result = await loadConversation(home, "alice", "default");
+    expect(result.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("appendConversationEntry writes a new entry to a fresh file", async () => {
+    await appendConversationEntry(home, "alice", "default", entry("a", 100));
+    const result = await loadConversation(home, "alice", "default");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("a");
+  });
+
+  it("appendConversationEntry appends to an existing file", async () => {
+    await appendConversationEntry(home, "alice", "default", entry("a", 100));
+    await appendConversationEntry(home, "alice", "default", entry("b", 200));
+    const result = await loadConversation(home, "alice", "default");
+    expect(result.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("saveConversation writes atomically (no .tmp residue)", async () => {
+    await saveConversation(home, "alice", "default", [entry("a", 100)]);
+    const { readdir } = await import("node:fs/promises");
+    const dir = join(home, "instances", "alice", "chats", "default");
+    const entries = await readdir(dir);
+    expect(entries).toEqual(["conversation.json"]);
+  });
+});

--- a/server-ts/src/conversation/store.ts
+++ b/server-ts/src/conversation/store.ts
@@ -1,0 +1,33 @@
+import { readJson, writeJson } from "../json-file.js";
+import { conversationFile } from "../paths.js";
+import { type Conversation, type ConversationEntry, ConversationSchema } from "./types.js";
+
+export async function loadConversation(
+  home: string,
+  slug: string,
+  chatId: string,
+): Promise<Conversation> {
+  const path = conversationFile(home, slug, chatId);
+  const existing = await readJson(path, ConversationSchema);
+  return (existing ?? []) as Conversation;
+}
+
+export async function saveConversation(
+  home: string,
+  slug: string,
+  chatId: string,
+  conversation: Conversation,
+): Promise<void> {
+  await writeJson(conversationFile(home, slug, chatId), conversation);
+}
+
+export async function appendConversationEntry(
+  home: string,
+  slug: string,
+  chatId: string,
+  entry: ConversationEntry,
+): Promise<void> {
+  const existing = await loadConversation(home, slug, chatId);
+  existing.push(entry);
+  await saveConversation(home, slug, chatId, existing);
+}

--- a/server-ts/src/conversation/types.test.ts
+++ b/server-ts/src/conversation/types.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { ContentBlockSchema, type ConversationEntry, ConversationEntrySchema } from "./types.js";
+
+describe("ContentBlockSchema", () => {
+  it("accepts a text block", () => {
+    const parsed = ContentBlockSchema.parse({ type: "text", text: "hi" });
+    expect(parsed).toEqual({ type: "text", text: "hi" });
+  });
+
+  it("accepts a tool_use block", () => {
+    const parsed = ContentBlockSchema.parse({
+      type: "tool_use",
+      id: "toolu_1",
+      name: "send_push",
+      input: { title: "hi" },
+    });
+    expect(parsed.type).toBe("tool_use");
+  });
+
+  it("accepts a tool_result block", () => {
+    const parsed = ContentBlockSchema.parse({
+      type: "tool_result",
+      tool_use_id: "toolu_1",
+      content: "done",
+    });
+    expect(parsed.type).toBe("tool_result");
+  });
+
+  it("rejects unknown block types", () => {
+    expect(() => ContentBlockSchema.parse({ type: "wut", x: 1 })).toThrow();
+  });
+});
+
+describe("ConversationEntrySchema", () => {
+  it("parses a minimal user entry", () => {
+    const entry = {
+      id: "msg_1",
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "hello" }],
+      ts: 1714000000000,
+    };
+    const parsed: ConversationEntry = ConversationEntrySchema.parse(entry);
+    expect(parsed.role).toBe("user");
+  });
+
+  it("parses an assistant entry with model field", () => {
+    const entry = {
+      id: "msg_2",
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: "hi back" }],
+      ts: 1714000001000,
+      model: "claude-sonnet-4-6",
+    };
+    const parsed = ConversationEntrySchema.parse(entry);
+    expect(parsed.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("rejects entries with invalid role", () => {
+    expect(() =>
+      ConversationEntrySchema.parse({
+        id: "msg_3",
+        role: "system",
+        content: [],
+        ts: 0,
+      }),
+    ).toThrow();
+  });
+});

--- a/server-ts/src/conversation/types.ts
+++ b/server-ts/src/conversation/types.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+export const TextBlockSchema = z.object({
+  type: z.literal("text"),
+  text: z.string(),
+});
+
+export const ToolUseBlockSchema = z.object({
+  type: z.literal("tool_use"),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  input: z.record(z.unknown()),
+});
+
+export const ToolResultBlockSchema = z.object({
+  type: z.literal("tool_result"),
+  tool_use_id: z.string().min(1),
+  content: z.string(),
+  is_error: z.boolean().optional(),
+});
+
+export const CompactionBlockSchema = z.object({
+  type: z.literal("compaction"),
+  content: z.string(),
+});
+
+export const ContentBlockSchema = z.discriminatedUnion("type", [
+  TextBlockSchema,
+  ToolUseBlockSchema,
+  ToolResultBlockSchema,
+  CompactionBlockSchema,
+]);
+export type ContentBlock = z.infer<typeof ContentBlockSchema>;
+
+export const ConversationRoleSchema = z.enum(["user", "assistant"]);
+export type ConversationRole = z.infer<typeof ConversationRoleSchema>;
+
+export const ConversationEntrySchema = z.object({
+  id: z.string().min(1),
+  role: ConversationRoleSchema,
+  content: z.array(ContentBlockSchema),
+  ts: z.number().int().nonnegative(),
+  model: z.string().optional(),
+});
+export type ConversationEntry = z.infer<typeof ConversationEntrySchema>;
+
+export const ConversationSchema = z.array(ConversationEntrySchema);
+export type Conversation = z.infer<typeof ConversationSchema>;

--- a/server-ts/src/e2e.test.ts
+++ b/server-ts/src/e2e.test.ts
@@ -1,0 +1,85 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Broadcaster } from "./events/broadcaster.js";
+import type { ServerEvent } from "./events/server-event.js";
+import { createApp } from "./http/server.js";
+import { MockAnthropicClient } from "./mind/mock-client.js";
+import { WorkerPool } from "./mind/pool.js";
+
+describe("E2E: HTTP chat → mind worker → WebSocket-style broadcast", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-e2e-"));
+    // Seed a minimal instance with soul.md
+    const instDir = join(home, "instances", "alice");
+    await mkdir(instDir, { recursive: true });
+    await writeFile(join(instDir, "soul.md"), "Alice's Bolly is helpful.");
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("POST /api/chat produces a full event sequence matching the Rust wire format", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_assist",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "Hi Alice, what's up?" }],
+        usage: { input_tokens: 200, output_tokens: 50 },
+      },
+    ]);
+
+    const broadcaster = new Broadcaster();
+    const received: ServerEvent[] = [];
+    broadcaster.subscribe((e) => received.push(e));
+
+    const pool = new WorkerPool({
+      clientFactory: () => client,
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster,
+    });
+
+    const { app } = createApp({ authToken: undefined, pool, broadcaster });
+
+    const res = await app.request("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        instance_slug: "alice",
+        chat_id: "default",
+        content: "hey",
+      }),
+    });
+    expect(res.status).toBe(202);
+
+    // handleUserMessage is fire-and-forget; wait for the worker to finish
+    // by polling for the AgentStopped event.
+    for (let i = 0; i < 100 && !received.some((e) => e.type === "agent_stopped"); i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    const types = received.map((e) => e.type);
+    expect(types).toContain("agent_running");
+    expect(types.filter((t) => t === "chat_message_created")).toHaveLength(2); // user + assistant
+    expect(types).toContain("agent_stopped");
+
+    // Verify the wire format is valid JSON the client expects
+    const assistantMsg = received.find(
+      (e): e is Extract<ServerEvent, { type: "chat_message_created" }> =>
+        e.type === "chat_message_created" && e.message.role === "Assistant",
+    );
+    expect(assistantMsg?.message.content).toBe("Hi Alice, what's up?");
+    expect(assistantMsg?.message.kind).toBe("Message");
+    expect(assistantMsg?.message.model).toBe("mock");
+  });
+});

--- a/server-ts/src/events/broadcaster.test.ts
+++ b/server-ts/src/events/broadcaster.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { Broadcaster } from "./broadcaster.js";
+import type { ServerEvent } from "./server-event.js";
+
+describe("Broadcaster", () => {
+  it("delivers an event to every subscriber", () => {
+    const b = new Broadcaster();
+    const a = vi.fn();
+    const c = vi.fn();
+    b.subscribe(a);
+    b.subscribe(c);
+
+    const event: ServerEvent = {
+      type: "agent_running",
+      instance_slug: "alice",
+      chat_id: "default",
+    };
+    b.emit(event);
+
+    expect(a).toHaveBeenCalledWith(event);
+    expect(c).toHaveBeenCalledWith(event);
+  });
+
+  it("unsubscribe stops delivery", () => {
+    const b = new Broadcaster();
+    const a = vi.fn();
+    const unsub = b.subscribe(a);
+    unsub();
+    b.emit({ type: "agent_running", instance_slug: "x", chat_id: "y" });
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it("isolates subscriber exceptions from other subscribers", () => {
+    const b = new Broadcaster();
+    b.subscribe(() => {
+      throw new Error("boom");
+    });
+    const ok = vi.fn();
+    b.subscribe(ok);
+    b.emit({ type: "agent_running", instance_slug: "x", chat_id: "y" });
+    expect(ok).toHaveBeenCalled();
+  });
+});

--- a/server-ts/src/events/broadcaster.ts
+++ b/server-ts/src/events/broadcaster.ts
@@ -1,0 +1,27 @@
+import type { ServerEvent } from "./server-event.js";
+
+export type Subscriber = (event: ServerEvent) => void;
+
+/**
+ * In-process pub-sub for ServerEvents. WebSocket handlers call subscribe()
+ * on connect; the mind worker calls emit() as events fire.
+ * Subscriber exceptions are caught so one bad client can't break others.
+ */
+export class Broadcaster {
+  private readonly subs = new Set<Subscriber>();
+
+  subscribe(fn: Subscriber): () => void {
+    this.subs.add(fn);
+    return () => this.subs.delete(fn);
+  }
+
+  emit(event: ServerEvent): void {
+    for (const fn of this.subs) {
+      try {
+        fn(event);
+      } catch (err) {
+        console.error("Broadcaster: subscriber threw", err);
+      }
+    }
+  }
+}

--- a/server-ts/src/events/server-event.test.ts
+++ b/server-ts/src/events/server-event.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { type ServerEvent, serializeServerEvent } from "./server-event.js";
+
+describe("serializeServerEvent", () => {
+  it("ChatMessageCreated matches the Rust wire format shape", () => {
+    const event: ServerEvent = {
+      type: "chat_message_created",
+      instance_slug: "alice",
+      chat_id: "default",
+      message: {
+        id: "msg_1",
+        role: "Assistant",
+        content: "hello",
+        created_at: "1714000000000",
+        kind: "Message",
+      },
+    };
+    const json = JSON.parse(serializeServerEvent(event));
+    expect(json.type).toBe("chat_message_created");
+    expect(json.instance_slug).toBe("alice");
+    expect(json.message.role).toBe("Assistant");
+  });
+
+  it("ChatStreamDelta carries message_id + delta", () => {
+    const event: ServerEvent = {
+      type: "chat_stream_delta",
+      instance_slug: "alice",
+      chat_id: "default",
+      message_id: "msg_2",
+      delta: "Hi ",
+    };
+    const json = JSON.parse(serializeServerEvent(event));
+    expect(json.type).toBe("chat_stream_delta");
+    expect(json.delta).toBe("Hi ");
+  });
+
+  it("AgentRunning / AgentStopped are bare signals", () => {
+    const running: ServerEvent = {
+      type: "agent_running",
+      instance_slug: "alice",
+      chat_id: "default",
+    };
+    const json = JSON.parse(serializeServerEvent(running));
+    expect(json).toEqual({
+      type: "agent_running",
+      instance_slug: "alice",
+      chat_id: "default",
+    });
+  });
+
+  it("ContextCompacting reports how many messages were compacted", () => {
+    const event: ServerEvent = {
+      type: "context_compacting",
+      instance_slug: "alice",
+      chat_id: "default",
+      messages_compacted: 42,
+    };
+    const json = JSON.parse(serializeServerEvent(event));
+    expect(json.messages_compacted).toBe(42);
+  });
+
+  it("ChatSnapshot replaces the whole chat state", () => {
+    const event: ServerEvent = {
+      type: "chat_snapshot",
+      instance_slug: "alice",
+      chat_id: "default",
+      messages: [],
+      agent_running: false,
+    };
+    const json = JSON.parse(serializeServerEvent(event));
+    expect(json.agent_running).toBe(false);
+  });
+});

--- a/server-ts/src/events/server-event.ts
+++ b/server-ts/src/events/server-event.ts
@@ -1,0 +1,61 @@
+/**
+ * ServerEvent — the WebSocket wire format. Byte-compatible with the Rust
+ * backend's existing serde(rename_all = "snake_case") tagged enum, so the
+ * SvelteKit client runs unmodified.
+ *
+ * This file intentionally defines only the variants Plan 2 emits. Plans 3
+ * (outreach), 4 (cross-instance), and 5 (polish) add the remaining variants
+ * (MoodUpdated, DropCreated, HeartbeatThought, McpAppStart, etc.) as their
+ * features land.
+ */
+export type ChatMessage = {
+  id: string;
+  role: "User" | "Assistant";
+  content: string;
+  created_at: string;
+  kind: "Message" | "ToolCall" | "ToolOutput" | "McpApp" | "Compaction";
+  tool_name?: string;
+  model?: string;
+};
+
+export type ServerEvent =
+  | {
+      type: "chat_message_created";
+      instance_slug: string;
+      chat_id: string;
+      message: ChatMessage;
+    }
+  | {
+      type: "chat_stream_delta";
+      instance_slug: string;
+      chat_id: string;
+      message_id: string;
+      delta: string;
+    }
+  | {
+      type: "agent_running";
+      instance_slug: string;
+      chat_id: string;
+    }
+  | {
+      type: "agent_stopped";
+      instance_slug: string;
+      chat_id: string;
+    }
+  | {
+      type: "context_compacting";
+      instance_slug: string;
+      chat_id: string;
+      messages_compacted: number;
+    }
+  | {
+      type: "chat_snapshot";
+      instance_slug: string;
+      chat_id: string;
+      messages: ChatMessage[];
+      agent_running: boolean;
+    };
+
+export function serializeServerEvent(event: ServerEvent): string {
+  return JSON.stringify(event);
+}

--- a/server-ts/src/fs-atomic.test.ts
+++ b/server-ts/src/fs-atomic.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { atomicWrite } from "./fs-atomic.js";
+
+describe("atomicWrite", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "bolly-atomic-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes content to the target path", async () => {
+    const target = join(dir, "hello.txt");
+    await atomicWrite(target, "hello world");
+    const contents = await readFile(target, "utf8");
+    expect(contents).toBe("hello world");
+  });
+
+  it("creates parent directories if missing", async () => {
+    const target = join(dir, "nested", "deep", "file.txt");
+    await atomicWrite(target, "ok");
+    const contents = await readFile(target, "utf8");
+    expect(contents).toBe("ok");
+  });
+
+  it("overwrites an existing file", async () => {
+    const target = join(dir, "overwrite.txt");
+    await writeFile(target, "old");
+    await atomicWrite(target, "new");
+    const contents = await readFile(target, "utf8");
+    expect(contents).toBe("new");
+  });
+
+  it("cleans up its .tmp file on success", async () => {
+    const target = join(dir, "cleanup.txt");
+    await atomicWrite(target, "body");
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(dir);
+    expect(entries).toEqual(["cleanup.txt"]);
+  });
+});

--- a/server-ts/src/fs-atomic.ts
+++ b/server-ts/src/fs-atomic.ts
@@ -1,13 +1,16 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 /**
- * Write body to path atomically by writing to a .tmp sibling and renaming.
+ * Write body to path atomically by writing to a unique .tmp sibling and renaming.
  * Mirrors the Rust backend's write-tmp-then-rename pattern.
+ * The temp suffix is randomized so two concurrent writers to the same path do
+ * not clobber each other's in-flight temp files.
  */
 export async function atomicWrite(path: string, body: string | Uint8Array): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp`;
+  const tmp = `${path}.${randomUUID()}.tmp`;
   await writeFile(tmp, body);
   await rename(tmp, path);
 }

--- a/server-ts/src/fs-atomic.ts
+++ b/server-ts/src/fs-atomic.ts
@@ -1,0 +1,13 @@
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+/**
+ * Write body to path atomically by writing to a .tmp sibling and renaming.
+ * Mirrors the Rust backend's write-tmp-then-rename pattern.
+ */
+export async function atomicWrite(path: string, body: string | Uint8Array): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, body);
+  await rename(tmp, path);
+}

--- a/server-ts/src/http/auth.test.ts
+++ b/server-ts/src/http/auth.test.ts
@@ -1,0 +1,41 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { requireAuth } from "./auth.js";
+
+function app(authToken: string | undefined) {
+  const h = new Hono();
+  h.use("*", requireAuth(authToken));
+  h.get("/ok", (c) => c.text("ok"));
+  return h;
+}
+
+describe("requireAuth", () => {
+  it("passes through when authToken is undefined (no auth configured)", async () => {
+    const res = await app(undefined).request("/ok");
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a matching Bearer token", async () => {
+    const res = await app("secret").request("/ok", {
+      headers: { Authorization: "Bearer secret" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a matching ?token= query param (for WebSocket)", async () => {
+    const res = await app("secret").request("/ok?token=secret");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 with no token", async () => {
+    const res = await app("secret").request("/ok");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 with a wrong token", async () => {
+    const res = await app("secret").request("/ok", {
+      headers: { Authorization: "Bearer wrong" },
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/server-ts/src/http/auth.ts
+++ b/server-ts/src/http/auth.ts
@@ -1,0 +1,21 @@
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Bearer-token or ?token= query-param auth.
+ * - If authToken is undefined, auth is disabled (dev).
+ * - Otherwise, requests must supply the token via either channel.
+ */
+export function requireAuth(authToken: string | undefined): MiddlewareHandler {
+  return async (c, next) => {
+    if (!authToken) return next();
+
+    const header = c.req.header("authorization") ?? "";
+    const bearer = header.startsWith("Bearer ") ? header.slice(7) : "";
+    const query = c.req.query("token") ?? "";
+
+    if (bearer === authToken || query === authToken) {
+      return next();
+    }
+    return c.text("Unauthorized", 401);
+  };
+}

--- a/server-ts/src/http/server.test.ts
+++ b/server-ts/src/http/server.test.ts
@@ -39,7 +39,7 @@ describe("createApp", () => {
       pricePerMTokOut: 15,
       broadcaster,
     });
-    const app = createApp({ authToken: undefined, pool, broadcaster });
+    const { app } = createApp({ authToken: undefined, pool, broadcaster });
 
     const res = await app.request("/api/chat", {
       method: "POST",
@@ -60,7 +60,7 @@ describe("createApp", () => {
       pricePerMTokOut: 15,
       broadcaster: new Broadcaster(),
     });
-    const app = createApp({ authToken: "secret", pool, broadcaster: new Broadcaster() });
+    const { app } = createApp({ authToken: "secret", pool, broadcaster: new Broadcaster() });
 
     const res = await app.request("/api/chat", {
       method: "POST",
@@ -80,7 +80,7 @@ describe("createApp", () => {
       pricePerMTokOut: 15,
       broadcaster: new Broadcaster(),
     });
-    const app = createApp({ authToken: undefined, pool, broadcaster: new Broadcaster() });
+    const { app } = createApp({ authToken: undefined, pool, broadcaster: new Broadcaster() });
 
     const res = await app.request("/api/health");
     expect(res.status).toBe(200);

--- a/server-ts/src/http/server.test.ts
+++ b/server-ts/src/http/server.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Broadcaster } from "../events/broadcaster.js";
+import { MockAnthropicClient } from "../mind/mock-client.js";
+import { WorkerPool } from "../mind/pool.js";
+import { createApp } from "./server.js";
+
+describe("createApp", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-http-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("POST /api/chat returns 202 and triggers the mind worker", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "ack" }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+    const broadcaster = new Broadcaster();
+    const pool = new WorkerPool({
+      clientFactory: () => client,
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster,
+    });
+    const app = createApp({ authToken: undefined, pool, broadcaster });
+
+    const res = await app.request("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ instance_slug: "alice", chat_id: "default", content: "hi" }),
+    });
+
+    expect(res.status).toBe(202);
+  });
+
+  it("POST /api/chat requires auth when configured", async () => {
+    const pool = new WorkerPool({
+      clientFactory: () => new MockAnthropicClient([]),
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster: new Broadcaster(),
+    });
+    const app = createApp({ authToken: "secret", pool, broadcaster: new Broadcaster() });
+
+    const res = await app.request("/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ instance_slug: "x", chat_id: "y", content: "hi" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/health returns 200", async () => {
+    const pool = new WorkerPool({
+      clientFactory: () => new MockAnthropicClient([]),
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster: new Broadcaster(),
+    });
+    const app = createApp({ authToken: undefined, pool, broadcaster: new Broadcaster() });
+
+    const res = await app.request("/api/health");
+    expect(res.status).toBe(200);
+  });
+});

--- a/server-ts/src/http/server.ts
+++ b/server-ts/src/http/server.ts
@@ -1,7 +1,10 @@
+import { createNodeWebSocket } from "@hono/node-ws";
 import { Hono } from "hono";
+import type { WSEvents } from "hono/ws";
 import type { Broadcaster } from "../events/broadcaster.js";
 import type { WorkerPool } from "../mind/pool.js";
 import { requireAuth } from "./auth.js";
+import { wsHandler } from "./ws.js";
 
 export type AppOptions = {
   authToken: string | undefined;
@@ -11,6 +14,7 @@ export type AppOptions = {
 
 export function createApp(opts: AppOptions) {
   const app = new Hono();
+  const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
 
   app.get("/api/health", (c) => c.json({ ok: true }));
 
@@ -24,13 +28,16 @@ export function createApp(opts: AppOptions) {
     }>();
 
     const worker = opts.pool.get(body.instance_slug, body.chat_id);
-    // Fire-and-forget: the mind turn runs asynchronously and broadcasts
-    // progress over WebSocket. The HTTP caller just gets a 202.
     void worker.handleUserMessage(body.content).catch((err) => {
       console.error("mind worker error", err);
     });
     return c.body(null, 202);
   });
 
-  return app;
+  // Cast needed because wsHandler uses WSEvents<unknown> to avoid importing
+  // the `ws` package type — upgradeWebSocket expects WSEvents<WebSocket>.
+  // biome-ignore lint/suspicious/noExplicitAny: bridging wsHandler's unknown generic to node-ws WebSocket
+  app.get("/api/ws", upgradeWebSocket(wsHandler(opts.broadcaster) as () => WSEvents<any>));
+
+  return { app, injectWebSocket };
 }

--- a/server-ts/src/http/server.ts
+++ b/server-ts/src/http/server.ts
@@ -1,0 +1,36 @@
+import { Hono } from "hono";
+import type { Broadcaster } from "../events/broadcaster.js";
+import type { WorkerPool } from "../mind/pool.js";
+import { requireAuth } from "./auth.js";
+
+export type AppOptions = {
+  authToken: string | undefined;
+  pool: WorkerPool;
+  broadcaster: Broadcaster;
+};
+
+export function createApp(opts: AppOptions) {
+  const app = new Hono();
+
+  app.get("/api/health", (c) => c.json({ ok: true }));
+
+  app.use("/api/*", requireAuth(opts.authToken));
+
+  app.post("/api/chat", async (c) => {
+    const body = await c.req.json<{
+      instance_slug: string;
+      chat_id: string;
+      content: string;
+    }>();
+
+    const worker = opts.pool.get(body.instance_slug, body.chat_id);
+    // Fire-and-forget: the mind turn runs asynchronously and broadcasts
+    // progress over WebSocket. The HTTP caller just gets a 202.
+    void worker.handleUserMessage(body.content).catch((err) => {
+      console.error("mind worker error", err);
+    });
+    return c.body(null, 202);
+  });
+
+  return app;
+}

--- a/server-ts/src/http/ws.ts
+++ b/server-ts/src/http/ws.ts
@@ -1,0 +1,45 @@
+import type { WSContext, WSEvents } from "hono/ws";
+import type { Broadcaster } from "../events/broadcaster.js";
+import { serializeServerEvent } from "../events/server-event.js";
+
+// Augment the raw socket type to hold the unsubscribe cleanup function.
+type RawWithUnsub = { _unsub?: () => void };
+
+/**
+ * Wire a Hono WebSocket to the Broadcaster. Returns a factory usable with
+ * @hono/node-ws's upgradeWebSocket.
+ *
+ * Auth is handled by the upgrade path (middleware + ?token= query param).
+ *
+ * Note: generic param is `unknown` because the concrete WebSocket type lives
+ * in the `ws` package which is not a direct dependency. The call site in
+ * server.ts casts to the correct type expected by createNodeWebSocket.
+ */
+export function wsHandler(broadcaster: Broadcaster): () => WSEvents<unknown> {
+  return () => ({
+    onOpen(_evt: unknown, ws: WSContext<unknown>) {
+      const unsub = broadcaster.subscribe((event) => {
+        try {
+          ws.send(serializeServerEvent(event));
+        } catch {
+          unsub();
+          ws.close();
+        }
+      });
+      // Stash the unsubscribe fn on the raw socket so onClose/onError can call it.
+      const raw = ws.raw as RawWithUnsub | undefined;
+      if (raw) raw._unsub = unsub;
+    },
+    onClose(_evt: unknown, ws: WSContext<unknown>) {
+      const raw = ws.raw as RawWithUnsub | undefined;
+      raw?._unsub?.();
+    },
+    onError(_evt: unknown, ws: WSContext<unknown>) {
+      const raw = ws.raw as RawWithUnsub | undefined;
+      raw?._unsub?.();
+    },
+    onMessage: () => {
+      // Clients don't need to send messages over WS — chat goes through POST /api/chat
+    },
+  });
+}

--- a/server-ts/src/index.test.ts
+++ b/server-ts/src/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import * as api from "./index.js";
+
+describe("public API", () => {
+  it("re-exports the foundational modules", () => {
+    expect(api.atomicWrite).toBeTypeOf("function");
+    expect(api.readJson).toBeTypeOf("function");
+    expect(api.writeJson).toBeTypeOf("function");
+    expect(api.readToml).toBeTypeOf("function");
+    expect(api.parseSkill).toBeTypeOf("function");
+    expect(api.loadSkills).toBeTypeOf("function");
+    expect(api.loadTriageRules).toBeTypeOf("function");
+    expect(api.buildTriagePrompt).toBeTypeOf("function");
+    expect(api.loadSettings).toBeTypeOf("function");
+    expect(api.appendOutreach).toBeTypeOf("function");
+    expect(api.readRecentOutreach).toBeTypeOf("function");
+    expect(api.computeState).toBeTypeOf("function");
+    expect(api.loadDaily).toBeTypeOf("function");
+    expect(api.recordSpend).toBeTypeOf("function");
+    expect(api.chargeAndCall).toBeTypeOf("function");
+    expect(api.Throttle).toBeTypeOf("function");
+    expect(api.todayUtc).toBeTypeOf("function");
+  });
+
+  it("re-exports path helpers", () => {
+    expect(api.instanceDir).toBeTypeOf("function");
+    expect(api.conversationFile).toBeTypeOf("function");
+  });
+
+  it("exposes DEFAULT_SETTINGS and DEFAULT_TRIAGE_TEMPLATE", () => {
+    expect(api.DEFAULT_SETTINGS).toBeDefined();
+    expect(api.DEFAULT_TRIAGE_TEMPLATE).toBeDefined();
+  });
+});

--- a/server-ts/src/index.test.ts
+++ b/server-ts/src/index.test.ts
@@ -32,3 +32,26 @@ describe("public API", () => {
     expect(api.DEFAULT_TRIAGE_TEMPLATE).toBeDefined();
   });
 });
+
+describe("Plan 2 public API", () => {
+  it("re-exports runtime config, conversation store, mind, events, http", () => {
+    expect(api.loadConfig).toBeTypeOf("function");
+    expect(api.loadConversation).toBeTypeOf("function");
+    expect(api.appendConversationEntry).toBeTypeOf("function");
+    expect(api.buildSystemPrompt).toBeTypeOf("function");
+    expect(api.skillToTool).toBeTypeOf("function");
+    expect(api.builtInTools).toBeTypeOf("function");
+    expect(api.createAnthropicClient).toBeTypeOf("function");
+    expect(api.MockAnthropicClient).toBeTypeOf("function");
+    expect(api.runMindTurn).toBeTypeOf("function");
+    expect(api.runMindWithTools).toBeTypeOf("function");
+    expect(api.runMindStreaming).toBeTypeOf("function");
+    expect(api.runBudgetedMind).toBeTypeOf("function");
+    expect(api.MindWorker).toBeTypeOf("function");
+    expect(api.WorkerPool).toBeTypeOf("function");
+    expect(api.Broadcaster).toBeTypeOf("function");
+    expect(api.serializeServerEvent).toBeTypeOf("function");
+    expect(api.createApp).toBeTypeOf("function");
+    expect(api.requireAuth).toBeTypeOf("function");
+  });
+});

--- a/server-ts/src/index.ts
+++ b/server-ts/src/index.ts
@@ -36,3 +36,54 @@ export {
   type CallOutcome,
 } from "./budget/charge-and-call.js";
 export { Throttle, type ThrottleConfig } from "./budget/throttle.js";
+
+// Plan 2 — Mind runtime
+export { loadConfig, type RuntimeConfig } from "./config.js";
+
+export {
+  loadConversation,
+  saveConversation,
+  appendConversationEntry,
+} from "./conversation/store.js";
+export {
+  ContentBlockSchema,
+  ConversationEntrySchema,
+  ConversationSchema,
+  type ContentBlock,
+  type ConversationEntry,
+  type Conversation,
+} from "./conversation/types.js";
+
+export { buildSystemPrompt, type SystemPromptInputs } from "./mind/system-prompt.js";
+export {
+  skillToTool,
+  skillToToolName,
+  builtInTools,
+  type ToolDefinition,
+} from "./mind/skill-tool.js";
+export { createAnthropicClient, type MindClient } from "./mind/anthropic-client.js";
+export { MockAnthropicClient, type MockMessage, type MockStream } from "./mind/mock-client.js";
+export {
+  runMindTurn,
+  runMindWithTools,
+  runMindStreaming,
+  type MindTurnInputs,
+  type MindTurnResult,
+  type MindFullTurnInputs,
+  type MindFullTurnResult,
+  type MindStreamingInputs,
+  type MindStreamingResult,
+} from "./mind/loop.js";
+export { runBudgetedMind, type BudgetedMindResult } from "./mind/budgeted-mind.js";
+export { MindWorker, type MindWorkerOptions } from "./mind/worker.js";
+export { WorkerPool, type WorkerPoolOptions } from "./mind/pool.js";
+
+export { Broadcaster, type Subscriber } from "./events/broadcaster.js";
+export {
+  serializeServerEvent,
+  type ServerEvent,
+  type ChatMessage,
+} from "./events/server-event.js";
+
+export { createApp, type AppOptions } from "./http/server.js";
+export { requireAuth } from "./http/auth.js";

--- a/server-ts/src/index.ts
+++ b/server-ts/src/index.ts
@@ -24,6 +24,7 @@ export { computeState, TIGHT_THRESHOLD } from "./budget/state.js";
 export {
   loadDaily,
   recordSpend,
+  recordSpendFromLoaded,
   todayUtc,
   type SpendDelta,
 } from "./budget/ledger.js";

--- a/server-ts/src/index.ts
+++ b/server-ts/src/index.ts
@@ -1,1 +1,37 @@
 export const VERSION = "1.0.0-alpha.0";
+
+export * from "./types.js";
+export * from "./paths.js";
+export { atomicWrite } from "./fs-atomic.js";
+export { readJson, writeJson } from "./json-file.js";
+export { readToml } from "./toml-file.js";
+
+export { parseSkill } from "./skills/parse.js";
+export { loadSkills, type LoadSkillsOptions } from "./skills/loader.js";
+
+export { loadTriageRules, DEFAULT_TRIAGE_TEMPLATE } from "./triage/rules.js";
+export {
+  buildTriagePrompt,
+  type OutreachHint,
+  type TriagePromptInputs,
+} from "./triage/prompt.js";
+
+export { loadSettings, DEFAULT_SETTINGS, type Settings } from "./settings/reader.js";
+
+export { appendOutreach, readRecentOutreach } from "./outreach/audit.js";
+
+export { computeState, TIGHT_THRESHOLD } from "./budget/state.js";
+export {
+  loadDaily,
+  recordSpend,
+  todayUtc,
+  type SpendDelta,
+} from "./budget/ledger.js";
+export {
+  chargeAndCall,
+  type ChargeContext,
+  type CallSuccess,
+  type CallDowngraded,
+  type CallOutcome,
+} from "./budget/charge-and-call.js";
+export { Throttle, type ThrottleConfig } from "./budget/throttle.js";

--- a/server-ts/src/index.ts
+++ b/server-ts/src/index.ts
@@ -1,0 +1,1 @@
+export const VERSION = "1.0.0-alpha.0";

--- a/server-ts/src/json-file.test.ts
+++ b/server-ts/src/json-file.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { readJson, writeJson } from "./json-file.js";
+
+const PersonSchema = z.object({ name: z.string(), age: z.number() });
+
+describe("readJson", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "bolly-json-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("parses a valid JSON file through the schema", async () => {
+    const f = join(dir, "person.json");
+    await writeFile(f, JSON.stringify({ name: "alice", age: 30 }));
+    const result = await readJson(f, PersonSchema);
+    expect(result).toEqual({ name: "alice", age: 30 });
+  });
+
+  it("returns null when the file is missing", async () => {
+    const f = join(dir, "missing.json");
+    const result = await readJson(f, PersonSchema);
+    expect(result).toBeNull();
+  });
+
+  it("throws when the JSON is malformed", async () => {
+    const f = join(dir, "broken.json");
+    await writeFile(f, "{ not valid");
+    await expect(readJson(f, PersonSchema)).rejects.toThrow(/parse/i);
+  });
+
+  it("throws when the shape fails schema validation", async () => {
+    const f = join(dir, "wrong.json");
+    await writeFile(f, JSON.stringify({ name: "alice", age: "thirty" }));
+    await expect(readJson(f, PersonSchema)).rejects.toThrow();
+  });
+});
+
+describe("writeJson", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "bolly-json-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes a pretty-printed JSON file that round-trips", async () => {
+    const f = join(dir, "round.json");
+    await writeJson(f, { name: "bob", age: 25 });
+    const roundTripped = await readJson(f, PersonSchema);
+    expect(roundTripped).toEqual({ name: "bob", age: 25 });
+  });
+});

--- a/server-ts/src/json-file.ts
+++ b/server-ts/src/json-file.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+import type { ZodSchema } from "zod";
+import { atomicWrite } from "./fs-atomic.js";
+
+/**
+ * Read a JSON file and validate it against a zod schema.
+ * Returns null if the file does not exist.
+ * Throws on parse errors or schema failures.
+ */
+export async function readJson<T>(path: string, schema: ZodSchema<T>): Promise<T | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`failed to parse JSON at ${path}: ${(err as Error).message}`);
+  }
+
+  return schema.parse(parsed);
+}
+
+/**
+ * Write a value as pretty JSON to path, atomically.
+ */
+export async function writeJson<T>(path: string, value: T): Promise<void> {
+  await atomicWrite(path, JSON.stringify(value, null, 2));
+}

--- a/server-ts/src/main.ts
+++ b/server-ts/src/main.ts
@@ -1,0 +1,64 @@
+import { serve } from "@hono/node-server";
+import { loadConfig } from "./config.js";
+import { Broadcaster } from "./events/broadcaster.js";
+import { createApp } from "./http/server.js";
+import { createAnthropicClient } from "./mind/anthropic-client.js";
+import { WorkerPool } from "./mind/pool.js";
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const SONNET_PRICE_IN = 3.0; // $/M input tokens
+const SONNET_PRICE_OUT = 15.0; // $/M output tokens
+const STALE_SWEEP_MS = 60_000; // once a minute
+
+function getCompanyName(env: NodeJS.ProcessEnv): string {
+  return env.BOLLY_COMPANY_NAME ?? "your company";
+}
+
+async function main() {
+  const config = loadConfig(process.env as Record<string, string | undefined>);
+
+  const broadcaster = new Broadcaster();
+  const pool = new WorkerPool({
+    clientFactory: () => createAnthropicClient(config.anthropicApiKey),
+    home: config.bollyHome,
+    companyName: getCompanyName(process.env),
+    model: DEFAULT_MODEL,
+    pricePerMTokIn: SONNET_PRICE_IN,
+    pricePerMTokOut: SONNET_PRICE_OUT,
+    broadcaster,
+  });
+
+  const { app, injectWebSocket } = createApp({
+    authToken: config.authToken,
+    pool,
+    broadcaster,
+  });
+
+  const server = serve({
+    fetch: app.fetch,
+    port: config.httpPort,
+  });
+  // biome-ignore lint/suspicious/noExplicitAny: @hono/node-server server type doesn't exactly match @hono/node-ws expected param
+  injectWebSocket(server as any);
+
+  const sweepInterval = setInterval(() => pool.sweepStale(Date.now()), STALE_SWEEP_MS);
+
+  const shutdown = (signal: string) => {
+    console.log(`received ${signal}, shutting down`);
+    clearInterval(sweepInterval);
+    server.close(() => {
+      process.exit(0);
+    });
+    setTimeout(() => process.exit(1), 10_000).unref();
+  };
+
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+
+  console.log(`Bolly v1.0 listening on port ${config.httpPort}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server-ts/src/mind/anthropic-client.test.ts
+++ b/server-ts/src/mind/anthropic-client.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { type MindClient, createAnthropicClient } from "./anthropic-client.js";
+
+describe("createAnthropicClient", () => {
+  it("returns an object with messages.create and messages.stream methods", () => {
+    const client: MindClient = createAnthropicClient("sk-ant-test");
+    expect(typeof client.messages.create).toBe("function");
+    expect(typeof client.messages.stream).toBe("function");
+  });
+});

--- a/server-ts/src/mind/anthropic-client.ts
+++ b/server-ts/src/mind/anthropic-client.ts
@@ -1,0 +1,22 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+/**
+ * The subset of the Anthropic SDK surface the mind uses.
+ * The mock client in tests implements this same interface.
+ */
+export type MindClient = {
+  messages: {
+    create: Anthropic["messages"]["create"];
+    stream: Anthropic["messages"]["stream"];
+  };
+};
+
+export function createAnthropicClient(apiKey: string): MindClient {
+  const client = new Anthropic({ apiKey });
+  return {
+    messages: {
+      create: client.messages.create.bind(client.messages),
+      stream: client.messages.stream.bind(client.messages),
+    },
+  };
+}

--- a/server-ts/src/mind/budgeted-mind.test.ts
+++ b/server-ts/src/mind/budgeted-mind.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { recordSpend } from "../budget/ledger.js";
+import { runBudgetedMind } from "./budgeted-mind.js";
+import { MockAnthropicClient } from "./mock-client.js";
+
+describe("runBudgetedMind", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-bm-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("runs the mind and records spend on the ledger", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 1000, output_tokens: 200 },
+      },
+    ]);
+
+    const result = await runBudgetedMind({
+      client,
+      home,
+      slug: "alice",
+      day: "2026-04-22",
+      capUsd: 2.0,
+      model: "mock",
+      pricePerMTokIn: 3.0,
+      pricePerMTokOut: 15.0,
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    expect(result.downgraded).toBeUndefined();
+    const { loadDaily } = await import("../budget/ledger.js");
+    const ledger = await loadDaily(home, "alice", "2026-04-22", 2.0);
+    // 1000 * 3/1M + 200 * 15/1M = 0.003 + 0.003 = 0.006
+    expect(ledger.dollars_spent).toBeCloseTo(0.006, 4);
+    expect(ledger.calls).toBe(1);
+  });
+
+  it("downgrades when budget is suppressed without invoking the client", async () => {
+    await recordSpend(home, "alice", "2026-04-22", 2.0, {
+      tokens_in: 0,
+      tokens_out: 0,
+      dollars: 2.5,
+    });
+
+    const client = new MockAnthropicClient([
+      {
+        id: "should-not-run",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+
+    const result = await runBudgetedMind({
+      client,
+      home,
+      slug: "alice",
+      day: "2026-04-22",
+      capUsd: 2.0,
+      model: "mock",
+      pricePerMTokIn: 3.0,
+      pricePerMTokOut: 15.0,
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    expect(result.downgraded).toBe(true);
+    expect(client.calls).toHaveLength(0);
+  });
+});

--- a/server-ts/src/mind/budgeted-mind.ts
+++ b/server-ts/src/mind/budgeted-mind.ts
@@ -1,0 +1,70 @@
+import { chargeAndCall } from "../budget/charge-and-call.js";
+import type { ConversationEntry } from "../conversation/types.js";
+import type { MindClient } from "./anthropic-client.js";
+import { type MindFullTurnResult, runMindWithTools } from "./loop.js";
+import type { ToolDefinition } from "./skill-tool.js";
+
+export type BudgetedMindInputs = {
+  client: MindClient;
+  home: string;
+  slug: string;
+  day: string;
+  capUsd: number;
+  model: string;
+  pricePerMTokIn: number;
+  pricePerMTokOut: number;
+  systemPrompt: string;
+  tools: ToolDefinition[];
+  conversation: ConversationEntry[];
+  userMessage: string;
+  executeTool: (name: string, input: Record<string, unknown>) => Promise<string>;
+  maxIterations: number;
+};
+
+export type BudgetedMindResult = MindFullTurnResult | { downgraded: true; reason: string };
+
+export async function runBudgetedMind(inputs: BudgetedMindInputs): Promise<BudgetedMindResult> {
+  const outcome = await chargeAndCall(
+    {
+      home: inputs.home,
+      slug: inputs.slug,
+      day: inputs.day,
+      capUsd: inputs.capUsd,
+      tier: 3,
+    },
+    async () => {
+      const result = await runMindWithTools({
+        client: inputs.client,
+        model: inputs.model,
+        systemPrompt: inputs.systemPrompt,
+        tools: inputs.tools,
+        conversation: inputs.conversation,
+        userMessage: inputs.userMessage,
+        executeTool: inputs.executeTool,
+        maxIterations: inputs.maxIterations,
+      });
+
+      const dollars =
+        (result.totalUsage.input_tokens * inputs.pricePerMTokIn) / 1_000_000 +
+        (result.totalUsage.output_tokens * inputs.pricePerMTokOut) / 1_000_000;
+
+      return {
+        ok: true as const,
+        value: result,
+        usage: {
+          tokens_in: result.totalUsage.input_tokens,
+          tokens_out: result.totalUsage.output_tokens,
+          dollars,
+        },
+      };
+    },
+  );
+
+  if ("downgraded" in outcome) {
+    return { downgraded: true, reason: outcome.reason };
+  }
+  if (!outcome.value) {
+    throw new Error("runBudgetedMind: expected value on success outcome");
+  }
+  return outcome.value;
+}

--- a/server-ts/src/mind/loop.test.ts
+++ b/server-ts/src/mind/loop.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { runMindTurn } from "./loop.js";
+import { runMindTurn, runMindWithTools } from "./loop.js";
 import { MockAnthropicClient } from "./mock-client.js";
 
 describe("runMindTurn — single-turn text", () => {
@@ -79,5 +79,141 @@ describe("runMindTurn — single-turn text", () => {
     });
 
     expect(client.calls[0]?.system).toBeDefined();
+  });
+});
+
+describe("runMindWithTools — tool-use loop", () => {
+  it("executes a tool call and continues to end_turn", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_a",
+            name: "send_push",
+            input: { title: "Q2 review", body: "urgent" },
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 10 },
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "sent" }],
+        usage: { input_tokens: 120, output_tokens: 5 },
+      },
+    ]);
+
+    const toolCalls: Array<{ name: string; input: unknown }> = [];
+    const result = await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "push me",
+      executeTool: async (name, input) => {
+        toolCalls.push({ name, input });
+        return "ok";
+      },
+      maxIterations: 5,
+    });
+
+    expect(toolCalls).toEqual([
+      { name: "send_push", input: { title: "Q2 review", body: "urgent" } },
+    ]);
+    expect(result.finalText).toBe("sent");
+    expect(result.turns).toBe(2);
+    expect(result.totalUsage.input_tokens).toBe(220);
+    expect(result.totalUsage.output_tokens).toBe(15);
+  });
+
+  it("stops with an error if an unknown tool is called", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_b",
+            name: "does_not_exist",
+            input: {},
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 10 },
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "caught error" }],
+        usage: { input_tokens: 120, output_tokens: 5 },
+      },
+    ]);
+
+    const result = await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "do it",
+      executeTool: async (name) => {
+        throw new Error(`unknown tool: ${name}`);
+      },
+      maxIterations: 5,
+    });
+
+    expect(result.finalText).toBe("caught error");
+    // Second call should have the is_error tool_result
+    const secondCall = client.calls[1];
+    const toolResult = secondCall?.messages[secondCall.messages.length - 1];
+    expect(toolResult?.role).toBe("user");
+    const firstBlock = (toolResult?.content as Array<{ type: string; is_error?: boolean }>)[0];
+    expect(firstBlock?.type).toBe("tool_result");
+    expect(firstBlock?.is_error).toBe(true);
+  });
+
+  it("stops at maxIterations", async () => {
+    const toolUseMsg = {
+      id: "msg_loop",
+      role: "assistant" as const,
+      model: "mock",
+      stop_reason: "tool_use" as const,
+      content: [
+        {
+          type: "tool_use" as const,
+          id: "toolu_x",
+          name: "send_push",
+          input: { title: "x", body: "y" },
+        },
+      ],
+      usage: { input_tokens: 10, output_tokens: 2 },
+    };
+    const client = new MockAnthropicClient([toolUseMsg, toolUseMsg, toolUseMsg]);
+
+    const result = await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "push me",
+      executeTool: async () => "ok",
+      maxIterations: 2,
+    });
+
+    expect(result.turns).toBe(2);
+    expect(result.hitMaxIterations).toBe(true);
   });
 });

--- a/server-ts/src/mind/loop.test.ts
+++ b/server-ts/src/mind/loop.test.ts
@@ -217,3 +217,74 @@ describe("runMindWithTools — tool-use loop", () => {
     expect(result.hitMaxIterations).toBe(true);
   });
 });
+
+describe("runMindWithTools — max_tokens continuation", () => {
+  it("re-prompts on stop_reason: max_tokens and merges output", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "max_tokens",
+        content: [{ type: "text", text: "part one" }],
+        usage: { input_tokens: 100, output_tokens: 4096 },
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "part two" }],
+        usage: { input_tokens: 200, output_tokens: 100 },
+      },
+    ]);
+
+    const result = await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "write a long thing",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    expect(result.finalText).toBe("part two");
+    expect(result.turns).toBe(2);
+    // Second call should include a continuation nudge as the last user message
+    const secondCall = client.calls[1];
+    const lastMsg = secondCall?.messages[secondCall.messages.length - 1];
+    expect(lastMsg?.role).toBe("user");
+    expect(JSON.stringify(lastMsg?.content)).toMatch(/continue/i);
+  });
+});
+
+describe("runMindWithTools — prompt caching", () => {
+  it("passes top-level cache_control: ephemeral by default", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+
+    await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    const call = client.calls[0] as unknown as { cache_control?: { type: string } };
+    expect(call.cache_control).toEqual({ type: "ephemeral" });
+  });
+});

--- a/server-ts/src/mind/loop.test.ts
+++ b/server-ts/src/mind/loop.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { runMindTurn, runMindWithTools } from "./loop.js";
+import { runMindStreaming, runMindTurn, runMindWithTools } from "./loop.js";
 import { MockAnthropicClient } from "./mock-client.js";
 
 describe("runMindTurn — single-turn text", () => {
@@ -362,5 +362,39 @@ describe("runMindWithTools — compaction", () => {
     const assistantTurn = secondCall?.messages.find((m) => m.role === "assistant");
     const blocks = assistantTurn?.content as Array<{ type: string }>;
     expect(blocks.find((b) => b.type === "compaction")).toBeDefined();
+  });
+});
+
+describe("runMindStreaming", () => {
+  it("emits delta callbacks as text streams in", async () => {
+    const client = new MockAnthropicClient([], {
+      streams: [
+        {
+          deltas: ["Hi ", "there"],
+          final: {
+            id: "msg_1",
+            role: "assistant",
+            model: "mock",
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "Hi there" }],
+            usage: { input_tokens: 10, output_tokens: 3 },
+          },
+        },
+      ],
+    });
+
+    const chunks: string[] = [];
+    const result = await runMindStreaming({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      onTextDelta: (text) => chunks.push(text),
+    });
+
+    expect(chunks).toEqual(["Hi ", "there"]);
+    expect(result.finalText).toBe("Hi there");
   });
 });

--- a/server-ts/src/mind/loop.test.ts
+++ b/server-ts/src/mind/loop.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { runMindTurn } from "./loop.js";
+import { MockAnthropicClient } from "./mock-client.js";
+
+describe("runMindTurn — single-turn text", () => {
+  it("sends a user message and returns the assistant text", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "hi there" }],
+        usage: { input_tokens: 100, output_tokens: 20 },
+      },
+    ]);
+
+    const result = await runMindTurn({
+      client,
+      model: "claude-sonnet-4-6",
+      systemPrompt: "You are Bolly.",
+      tools: [],
+      conversation: [],
+      userMessage: "hello",
+    });
+
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.assistantContent).toEqual([{ type: "text", text: "hi there" }]);
+    expect(result.totalUsage.input_tokens).toBe(100);
+    expect(result.totalUsage.output_tokens).toBe(20);
+  });
+
+  it("passes the full message array including the new user message", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 50, output_tokens: 5 },
+      },
+    ]);
+
+    await runMindTurn({
+      client,
+      model: "claude-sonnet-4-6",
+      systemPrompt: "You are Bolly.",
+      tools: [],
+      conversation: [{ id: "p1", role: "user", content: [{ type: "text", text: "prior" }], ts: 1 }],
+      userMessage: "hello",
+    });
+
+    const call = client.calls[0];
+    expect(call?.messages).toHaveLength(2);
+    expect(call?.messages[0]?.content).toEqual([{ type: "text", text: "prior" }]);
+    expect(call?.messages[1]?.content).toBe("hello");
+  });
+
+  it("includes the system prompt on the request", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+
+    await runMindTurn({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+    });
+
+    expect(client.calls[0]?.system).toBeDefined();
+  });
+});

--- a/server-ts/src/mind/loop.test.ts
+++ b/server-ts/src/mind/loop.test.ts
@@ -288,3 +288,79 @@ describe("runMindWithTools — prompt caching", () => {
     expect(call.cache_control).toEqual({ type: "ephemeral" });
   });
 });
+
+describe("runMindWithTools — compaction", () => {
+  it("passes context_management and the compact beta header", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "." }],
+        usage: { input_tokens: 10, output_tokens: 1 },
+      },
+    ]);
+
+    await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "hi",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    const call = client.calls[0] as unknown as {
+      context_management?: { edits: Array<{ type: string }> };
+      betas?: string[];
+    };
+    expect(call.context_management?.edits?.[0]?.type).toBe("compact_20260112");
+    expect(call.betas).toContain("compact-2026-01-12");
+  });
+
+  it("preserves compaction blocks across turns", async () => {
+    // Turn 1: max_tokens (forces a continuation turn) with a compaction block
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "max_tokens",
+        content: [
+          { type: "compaction", content: "earlier conversation summary" },
+          { type: "text", text: "new text after compaction" },
+        ],
+        usage: { input_tokens: 160_000, output_tokens: 4096 },
+      },
+      {
+        id: "msg_2",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "done" }],
+        usage: { input_tokens: 50_000, output_tokens: 100 },
+      },
+    ]);
+
+    await runMindWithTools({
+      client,
+      model: "mock",
+      systemPrompt: "SYSTEM",
+      tools: [],
+      conversation: [],
+      userMessage: "long request",
+      executeTool: async () => "unused",
+      maxIterations: 5,
+    });
+
+    // The second call's message history must include the compaction block on
+    // the assistant turn from message 1 (not just the text).
+    const secondCall = client.calls[1];
+    const assistantTurn = secondCall?.messages.find((m) => m.role === "assistant");
+    const blocks = assistantTurn?.content as Array<{ type: string }>;
+    expect(blocks.find((b) => b.type === "compaction")).toBeDefined();
+  });
+});

--- a/server-ts/src/mind/loop.test.ts
+++ b/server-ts/src/mind/loop.test.ts
@@ -250,7 +250,11 @@ describe("runMindWithTools — max_tokens continuation", () => {
       maxIterations: 5,
     });
 
-    expect(result.finalText).toBe("part two");
+    expect(result.finalText).toBe("part onepart two");
+    expect(result.assistantContent).toEqual([
+      { type: "text", text: "part one" },
+      { type: "text", text: "part two" },
+    ]);
     expect(result.turns).toBe(2);
     // Second call should include a continuation nudge as the last user message
     const secondCall = client.calls[1];

--- a/server-ts/src/mind/loop.ts
+++ b/server-ts/src/mind/loop.ts
@@ -115,7 +115,16 @@ export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<Mind
       tools: tools as unknown as Anthropic.Messages.ToolUnion[],
       messages,
       cache_control: { type: "ephemeral" },
-      // biome-ignore lint/suspicious/noExplicitAny: top-level cache_control is not in the typed params yet
+      context_management: {
+        edits: [
+          {
+            type: "compact_20260112",
+            trigger: { type: "input_tokens", value: 150_000 },
+          },
+        ],
+      },
+      betas: ["compact-2026-01-12"],
+      // biome-ignore lint/suspicious/noExplicitAny: top-level cache_control / context_management / betas are not in the typed params yet
     } as any);
 
     totalInput += response.usage.input_tokens;

--- a/server-ts/src/mind/loop.ts
+++ b/server-ts/src/mind/loop.ts
@@ -104,6 +104,12 @@ export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<Mind
   let totalCacheCreation = 0;
 
   let lastAssistantContent: ContentBlock[] = [];
+  // When stop_reason is max_tokens, Claude's response was cut off mid-sentence
+  // and the next turn continues from where it left off. We accumulate the
+  // truncated text blocks so the caller (MindWorker) can persist a complete
+  // assistant response instead of losing the pre-continuation content.
+  const accumulatedPriorBlocks: ContentBlock[] = [];
+  let accumulatedPriorText = "";
   let turns = 0;
 
   for (let i = 0; i < maxIterations; i++) {
@@ -144,6 +150,14 @@ export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<Mind
     ];
 
     if (response.stop_reason === "max_tokens") {
+      // Preserve this turn's text so finalText + assistantContent aren't
+      // silently truncated when the continuation completes.
+      for (const block of lastAssistantContent) {
+        if (block.type === "text") {
+          accumulatedPriorBlocks.push(block);
+          accumulatedPriorText += block.text;
+        }
+      }
       messages = [...messages, { role: "user", content: CONTINUATION_PROMPT }];
       continue;
     }
@@ -172,16 +186,17 @@ export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<Mind
     messages = [...messages, { role: "user", content: toolResultBlocks }];
   }
 
-  const finalText = lastAssistantContent
+  const finalTurnText = lastAssistantContent
     .filter((b) => b.type === "text")
     .map((b) => (b as { type: "text"; text: string }).text)
     .join("");
+  const finalText = accumulatedPriorText + finalTurnText;
 
   return {
     finalText,
     turns,
     hitMaxIterations: turns >= maxIterations,
-    assistantContent: lastAssistantContent,
+    assistantContent: [...accumulatedPriorBlocks, ...lastAssistantContent],
     totalUsage: {
       input_tokens: totalInput,
       output_tokens: totalOutput,

--- a/server-ts/src/mind/loop.ts
+++ b/server-ts/src/mind/loop.ts
@@ -67,3 +67,108 @@ export async function runMindTurn(inputs: MindTurnInputs): Promise<MindTurnResul
     },
   };
 }
+
+export type MindFullTurnInputs = MindTurnInputs & {
+  executeTool: (name: string, input: Record<string, unknown>) => Promise<string>;
+  maxIterations: number;
+};
+
+export type MindFullTurnResult = {
+  finalText: string;
+  turns: number;
+  hitMaxIterations: boolean;
+  assistantContent: ContentBlock[];
+  totalUsage: MindTurnResult["totalUsage"];
+};
+
+/**
+ * Run the mind in a loop until Claude stops calling tools or maxIterations
+ * is reached. Each tool_use block is executed via the supplied executeTool
+ * callback; errors become is_error: true tool_result blocks rather than
+ * throwing, so Claude can observe and recover.
+ */
+export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<MindFullTurnResult> {
+  const { client, model, systemPrompt, tools, executeTool, maxIterations } = inputs;
+
+  let messages: Anthropic.Messages.MessageParam[] = [
+    ...conversationToMessages(inputs.conversation),
+    { role: "user", content: inputs.userMessage },
+  ];
+
+  let totalInput = 0;
+  let totalOutput = 0;
+  let totalCacheRead = 0;
+  let totalCacheCreation = 0;
+
+  let lastAssistantContent: ContentBlock[] = [];
+  let turns = 0;
+
+  for (let i = 0; i < maxIterations; i++) {
+    turns++;
+    const response = await client.messages.create({
+      model,
+      max_tokens: 4096,
+      system: systemPrompt,
+      tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+      messages,
+    });
+
+    totalInput += response.usage.input_tokens;
+    totalOutput += response.usage.output_tokens;
+    totalCacheRead += response.usage.cache_read_input_tokens ?? 0;
+    totalCacheCreation += response.usage.cache_creation_input_tokens ?? 0;
+
+    lastAssistantContent = response.content as unknown as ContentBlock[];
+
+    // Append assistant turn to the running history
+    messages = [
+      ...messages,
+      {
+        role: "assistant",
+        content: response.content as unknown as Anthropic.Messages.ContentBlockParam[],
+      },
+    ];
+
+    if (response.stop_reason !== "tool_use") break;
+
+    // Execute each tool_use block and produce tool_result blocks
+    const toolResultBlocks: Anthropic.Messages.ContentBlockParam[] = [];
+    for (const block of response.content) {
+      if (block.type !== "tool_use") continue;
+      let content: string;
+      let isError = false;
+      try {
+        content = await executeTool(block.name, block.input as Record<string, unknown>);
+      } catch (err) {
+        content = `error: ${(err as Error).message}`;
+        isError = true;
+      }
+      toolResultBlocks.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content,
+        is_error: isError,
+      });
+    }
+
+    messages = [...messages, { role: "user", content: toolResultBlocks }];
+  }
+
+  const finalText = lastAssistantContent
+    .filter((b) => b.type === "text")
+    .map((b) => (b as { type: "text"; text: string }).text)
+    .join("");
+
+  return {
+    finalText,
+    turns,
+    hitMaxIterations: turns >= maxIterations,
+    assistantContent: lastAssistantContent,
+    totalUsage: {
+      input_tokens: totalInput,
+      output_tokens: totalOutput,
+      cache_read_input_tokens: totalCacheRead,
+      cache_creation_input_tokens: totalCacheCreation,
+    },
+  };
+}

--- a/server-ts/src/mind/loop.ts
+++ b/server-ts/src/mind/loop.ts
@@ -1,0 +1,69 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ContentBlock, ConversationEntry } from "../conversation/types.js";
+import type { MindClient } from "./anthropic-client.js";
+import type { ToolDefinition } from "./skill-tool.js";
+
+export type MindTurnInputs = {
+  client: MindClient;
+  model: string;
+  systemPrompt: string;
+  tools: ToolDefinition[];
+  conversation: ConversationEntry[];
+  userMessage: string;
+};
+
+export type MindTurnResult = {
+  stopReason: string;
+  assistantContent: ContentBlock[];
+  totalUsage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens: number;
+  };
+};
+
+/**
+ * Convert a Conversation into the Anthropic messages array shape.
+ * Each entry becomes one role-tagged message; content blocks pass through.
+ */
+function conversationToMessages(
+  conversation: ConversationEntry[],
+): Anthropic.Messages.MessageParam[] {
+  return conversation.map((e) => ({
+    role: e.role,
+    content: e.content as unknown as Anthropic.Messages.ContentBlockParam[],
+  }));
+}
+
+/**
+ * Run a single mind turn without tool use or continuation.
+ * Higher-level wrappers compose multiple turns for tool use etc.
+ */
+export async function runMindTurn(inputs: MindTurnInputs): Promise<MindTurnResult> {
+  const { client, model, systemPrompt, tools, conversation, userMessage } = inputs;
+
+  const messages: Anthropic.Messages.MessageParam[] = [
+    ...conversationToMessages(conversation),
+    { role: "user", content: userMessage },
+  ];
+
+  const response = await client.messages.create({
+    model,
+    max_tokens: 4096,
+    system: systemPrompt,
+    tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+    messages,
+  });
+
+  return {
+    stopReason: response.stop_reason ?? "end_turn",
+    assistantContent: response.content as unknown as ContentBlock[],
+    totalUsage: {
+      input_tokens: response.usage.input_tokens,
+      output_tokens: response.usage.output_tokens,
+      cache_read_input_tokens: response.usage.cache_read_input_tokens ?? 0,
+      cache_creation_input_tokens: response.usage.cache_creation_input_tokens ?? 0,
+    },
+  };
+}

--- a/server-ts/src/mind/loop.ts
+++ b/server-ts/src/mind/loop.ts
@@ -190,3 +190,57 @@ export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<Mind
     },
   };
 }
+
+export type MindStreamingInputs = MindTurnInputs & {
+  onTextDelta: (text: string) => void;
+};
+
+export type MindStreamingResult = {
+  finalText: string;
+  assistantContent: ContentBlock[];
+  totalUsage: MindTurnResult["totalUsage"];
+};
+
+export async function runMindStreaming(inputs: MindStreamingInputs): Promise<MindStreamingResult> {
+  const { client, model, systemPrompt, tools, onTextDelta } = inputs;
+
+  const messages: Anthropic.Messages.MessageParam[] = [
+    ...conversationToMessages(inputs.conversation),
+    { role: "user", content: inputs.userMessage },
+  ];
+
+  const stream = client.messages.stream({
+    model,
+    max_tokens: 4096,
+    system: systemPrompt,
+    tools: tools as unknown as Anthropic.Messages.ToolUnion[],
+    messages,
+    cache_control: { type: "ephemeral" },
+    context_management: {
+      edits: [{ type: "compact_20260112", trigger: { type: "input_tokens", value: 150_000 } }],
+    },
+    betas: ["compact-2026-01-12"],
+    // biome-ignore lint/suspicious/noExplicitAny: top-level cache_control / context_management / betas are not in the typed params yet
+  } as any);
+
+  for await (const event of stream) {
+    if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+      onTextDelta(event.delta.text);
+    }
+  }
+
+  const final = await stream.finalMessage();
+  return {
+    finalText: final.content
+      .filter((b: { type: string }) => b.type === "text")
+      .map((b: unknown) => (b as { text: string }).text)
+      .join(""),
+    assistantContent: final.content as unknown as ContentBlock[],
+    totalUsage: {
+      input_tokens: final.usage.input_tokens,
+      output_tokens: final.usage.output_tokens,
+      cache_read_input_tokens: final.usage.cache_read_input_tokens ?? 0,
+      cache_creation_input_tokens: final.usage.cache_creation_input_tokens ?? 0,
+    },
+  };
+}

--- a/server-ts/src/mind/loop.ts
+++ b/server-ts/src/mind/loop.ts
@@ -3,6 +3,9 @@ import type { ContentBlock, ConversationEntry } from "../conversation/types.js";
 import type { MindClient } from "./anthropic-client.js";
 import type { ToolDefinition } from "./skill-tool.js";
 
+const CONTINUATION_PROMPT =
+  "[system: your previous response was cut off due to length. please continue exactly where you left off.]";
+
 export type MindTurnInputs = {
   client: MindClient;
   model: string;
@@ -111,7 +114,9 @@ export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<Mind
       system: systemPrompt,
       tools: tools as unknown as Anthropic.Messages.ToolUnion[],
       messages,
-    });
+      cache_control: { type: "ephemeral" },
+      // biome-ignore lint/suspicious/noExplicitAny: top-level cache_control is not in the typed params yet
+    } as any);
 
     totalInput += response.usage.input_tokens;
     totalOutput += response.usage.output_tokens;
@@ -129,6 +134,10 @@ export async function runMindWithTools(inputs: MindFullTurnInputs): Promise<Mind
       },
     ];
 
+    if (response.stop_reason === "max_tokens") {
+      messages = [...messages, { role: "user", content: CONTINUATION_PROMPT }];
+      continue;
+    }
     if (response.stop_reason !== "tool_use") break;
 
     // Execute each tool_use block and produce tool_result blocks

--- a/server-ts/src/mind/mock-client.test.ts
+++ b/server-ts/src/mind/mock-client.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { MockAnthropicClient, type MockMessage } from "./mock-client.js";
+
+const TEXT_MESSAGE: MockMessage = {
+  id: "msg_1",
+  role: "assistant",
+  model: "mock",
+  stop_reason: "end_turn",
+  content: [{ type: "text", text: "hello" }],
+  usage: { input_tokens: 100, output_tokens: 20 },
+};
+
+const TOOL_USE_MESSAGE: MockMessage = {
+  id: "msg_2",
+  role: "assistant",
+  model: "mock",
+  stop_reason: "tool_use",
+  content: [
+    {
+      type: "tool_use",
+      id: "toolu_1",
+      name: "send_push",
+      input: { title: "hi", body: "there" },
+    },
+  ],
+  usage: { input_tokens: 120, output_tokens: 30 },
+};
+
+describe("MockAnthropicClient.messages.create", () => {
+  it("returns queued messages in FIFO order", async () => {
+    const client = new MockAnthropicClient([TEXT_MESSAGE]);
+    const m = await client.messages.create({
+      model: "mock",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(m.content[0]).toEqual({ type: "text", text: "hello" });
+  });
+
+  it("records each call so tests can assert on the request shape", async () => {
+    const client = new MockAnthropicClient([TEXT_MESSAGE]);
+    await client.messages.create({
+      model: "mock",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]?.messages[0]?.content).toBe("hi");
+  });
+
+  it("throws when queue is empty", async () => {
+    const client = new MockAnthropicClient([]);
+    await expect(
+      client.messages.create({
+        model: "mock",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    ).rejects.toThrow(/no queued response/i);
+  });
+
+  it("supports a tool_use stop reason", async () => {
+    const client = new MockAnthropicClient([TOOL_USE_MESSAGE]);
+    const m = await client.messages.create({
+      model: "mock",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "push me" }],
+    });
+    expect(m.stop_reason).toBe("tool_use");
+    expect(m.content[0]).toMatchObject({ type: "tool_use", name: "send_push" });
+  });
+});

--- a/server-ts/src/mind/mock-client.test.ts
+++ b/server-ts/src/mind/mock-client.test.ts
@@ -70,3 +70,27 @@ describe("MockAnthropicClient.messages.create", () => {
     expect(m.content[0]).toMatchObject({ type: "tool_use", name: "send_push" });
   });
 });
+
+describe("MockAnthropicClient.messages.stream", () => {
+  it("yields queued delta strings and returns a final message", async () => {
+    const client = new MockAnthropicClient([], {
+      streams: [{ deltas: ["Hel", "lo!"], final: TEXT_MESSAGE }],
+    });
+
+    const stream = client.messages.stream({
+      model: "mock",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    const collected: string[] = [];
+    for await (const event of stream) {
+      if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+        collected.push(event.delta.text);
+      }
+    }
+    expect(collected).toEqual(["Hel", "lo!"]);
+    const final = await stream.finalMessage();
+    expect(final.content[0]).toEqual({ type: "text", text: "hello" });
+  });
+});

--- a/server-ts/src/mind/mock-client.ts
+++ b/server-ts/src/mind/mock-client.ts
@@ -1,0 +1,49 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import type { MindClient } from "./anthropic-client.js";
+
+export type MockMessage = {
+  id: string;
+  role: "assistant";
+  model: string;
+  stop_reason: "end_turn" | "tool_use" | "max_tokens" | "stop_sequence" | "pause_turn" | "refusal";
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+    | { type: "compaction"; content: string }
+  >;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+};
+
+type CreateParams = Anthropic.Messages.MessageCreateParamsNonStreaming;
+
+/**
+ * In-memory Anthropic client that replays a queue of canned messages.
+ * Records every call for later assertion. Implements the same shape as
+ * MindClient so the loop can accept either one.
+ */
+export class MockAnthropicClient implements MindClient {
+  readonly calls: CreateParams[] = [];
+  private readonly queue: MockMessage[];
+
+  constructor(responses: MockMessage[]) {
+    this.queue = [...responses];
+  }
+
+  readonly messages = {
+    create: async (params: CreateParams): Promise<MockMessage> => {
+      this.calls.push(params);
+      const next = this.queue.shift();
+      if (!next) throw new Error("MockAnthropicClient: no queued response");
+      return next;
+    },
+    // Streaming mock ships in Task 13; create alone covers Tasks 9-12.
+    stream: (): never => {
+      throw new Error("MockAnthropicClient.stream: not implemented in this fixture");
+    },
+  } as unknown as MindClient["messages"];
+}

--- a/server-ts/src/mind/mock-client.ts
+++ b/server-ts/src/mind/mock-client.ts
@@ -21,6 +21,11 @@ export type MockMessage = {
 
 type CreateParams = Anthropic.Messages.MessageCreateParamsNonStreaming;
 
+export type MockStream = {
+  deltas: string[];
+  final: MockMessage;
+};
+
 /**
  * In-memory Anthropic client that replays a queue of canned messages.
  * Records every call for later assertion. Implements the same shape as
@@ -28,10 +33,13 @@ type CreateParams = Anthropic.Messages.MessageCreateParamsNonStreaming;
  */
 export class MockAnthropicClient implements MindClient {
   readonly calls: CreateParams[] = [];
+  readonly streamCalls: CreateParams[] = [];
   private readonly queue: MockMessage[];
+  private readonly streamQueue: MockStream[];
 
-  constructor(responses: MockMessage[]) {
+  constructor(responses: MockMessage[], opts: { streams?: MockStream[] } = {}) {
     this.queue = [...responses];
+    this.streamQueue = [...(opts.streams ?? [])];
   }
 
   readonly messages = {
@@ -41,9 +49,33 @@ export class MockAnthropicClient implements MindClient {
       if (!next) throw new Error("MockAnthropicClient: no queued response");
       return next;
     },
-    // Streaming mock ships in Task 13; create alone covers Tasks 9-12.
-    stream: (): never => {
-      throw new Error("MockAnthropicClient.stream: not implemented in this fixture");
+    stream: (params: CreateParams) => {
+      this.streamCalls.push(params);
+      const next = this.streamQueue.shift();
+      if (!next) throw new Error("MockAnthropicClient.stream: no queued stream");
+      const { deltas, final } = next;
+
+      async function* events() {
+        yield { type: "message_start", message: { id: final.id } };
+        yield { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } };
+        for (const delta of deltas) {
+          yield {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: delta },
+          };
+        }
+        yield { type: "content_block_stop", index: 0 };
+        yield { type: "message_stop" };
+      }
+
+      const iter = events();
+      return {
+        [Symbol.asyncIterator]() {
+          return iter;
+        },
+        finalMessage: async () => final,
+      };
     },
   } as unknown as MindClient["messages"];
 }

--- a/server-ts/src/mind/pool.test.ts
+++ b/server-ts/src/mind/pool.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Broadcaster } from "../events/broadcaster.js";
+import { MockAnthropicClient } from "./mock-client.js";
+import { WorkerPool } from "./pool.js";
+
+describe("WorkerPool", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-pool-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("creates one worker per (slug, chatId) on demand", () => {
+    const pool = new WorkerPool({
+      clientFactory: () => new MockAnthropicClient([]),
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster: new Broadcaster(),
+    });
+
+    const a = pool.get("alice", "default");
+    const a2 = pool.get("alice", "default");
+    const b = pool.get("bob", "default");
+
+    expect(a).toBe(a2);
+    expect(a).not.toBe(b);
+  });
+
+  it("sweepStale removes workers past their TTL", () => {
+    const pool = new WorkerPool({
+      clientFactory: () => new MockAnthropicClient([]),
+      home,
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3,
+      pricePerMTokOut: 15,
+      broadcaster: new Broadcaster(),
+      warmTtlMs: 1000,
+    });
+
+    const w = pool.get("alice", "default");
+    w.touch(1_000_000);
+    pool.sweepStale(1_000_500);
+    expect(pool.get("alice", "default")).toBe(w);
+
+    pool.sweepStale(1_100_000);
+    expect(pool.get("alice", "default")).not.toBe(w);
+  });
+});

--- a/server-ts/src/mind/pool.ts
+++ b/server-ts/src/mind/pool.ts
@@ -1,0 +1,55 @@
+import type { Broadcaster } from "../events/broadcaster.js";
+import type { MindClient } from "./anthropic-client.js";
+import { MindWorker } from "./worker.js";
+
+export type WorkerPoolOptions = {
+  clientFactory: () => MindClient;
+  home: string;
+  companyName: string;
+  model: string;
+  pricePerMTokIn: number;
+  pricePerMTokOut: number;
+  broadcaster: Broadcaster;
+  warmTtlMs?: number;
+};
+
+export class WorkerPool {
+  private readonly workers = new Map<string, MindWorker>();
+
+  constructor(private readonly opts: WorkerPoolOptions) {}
+
+  private key(slug: string, chatId: string): string {
+    return `${slug}/${chatId}`;
+  }
+
+  get(slug: string, chatId: string): MindWorker {
+    const k = this.key(slug, chatId);
+    const existing = this.workers.get(k);
+    if (existing) return existing;
+
+    const worker = new MindWorker({
+      client: this.opts.clientFactory(),
+      home: this.opts.home,
+      slug,
+      chatId,
+      companyName: this.opts.companyName,
+      model: this.opts.model,
+      pricePerMTokIn: this.opts.pricePerMTokIn,
+      pricePerMTokOut: this.opts.pricePerMTokOut,
+      broadcaster: this.opts.broadcaster,
+      ...(this.opts.warmTtlMs !== undefined ? { warmTtlMs: this.opts.warmTtlMs } : {}),
+    });
+    this.workers.set(k, worker);
+    return worker;
+  }
+
+  sweepStale(nowMs: number): void {
+    for (const [k, w] of this.workers) {
+      if (w.isStaleAt(nowMs)) this.workers.delete(k);
+    }
+  }
+
+  size(): number {
+    return this.workers.size;
+  }
+}

--- a/server-ts/src/mind/skill-tool.test.ts
+++ b/server-ts/src/mind/skill-tool.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../types.js";
+import { builtInTools, skillToTool, skillToToolName } from "./skill-tool.js";
+
+const SKILL: Skill = {
+  frontmatter: {
+    name: "email-morning-check",
+    triggers: [],
+    tools: [],
+    enabled: true,
+  },
+  body: "Read unread email and summarize urgent items.",
+  path: "/skills/x.md",
+};
+
+describe("skillToToolName", () => {
+  it("prefixes with run_ and replaces dashes with underscores", () => {
+    expect(skillToToolName("email-morning-check")).toBe("run_email_morning_check");
+  });
+
+  it("preserves underscores", () => {
+    expect(skillToToolName("simple_name")).toBe("run_simple_name");
+  });
+});
+
+describe("skillToTool", () => {
+  it("produces a tool definition with the right name and description", () => {
+    const tool = skillToTool(SKILL);
+    expect(tool.name).toBe("run_email_morning_check");
+    expect(tool.description).toContain("Read unread email");
+  });
+
+  it("accepts an input schema with a free-form context argument", () => {
+    const tool = skillToTool(SKILL);
+    expect(tool.input_schema.type).toBe("object");
+    expect(tool.input_schema.properties).toHaveProperty("context");
+  });
+});
+
+describe("builtInTools", () => {
+  it("provides send_push, send_email, defer_for_digest", () => {
+    const names = builtInTools().map((t) => t.name);
+    expect(names).toContain("send_push");
+    expect(names).toContain("send_email");
+    expect(names).toContain("defer_for_digest");
+  });
+
+  it("send_push has a title and body schema", () => {
+    const push = builtInTools().find((t) => t.name === "send_push");
+    expect(push?.input_schema.required).toContain("title");
+    expect(push?.input_schema.required).toContain("body");
+  });
+});

--- a/server-ts/src/mind/skill-tool.ts
+++ b/server-ts/src/mind/skill-tool.ts
@@ -1,0 +1,3 @@
+export function skillToToolName(skillName: string): string {
+  return `run_${skillName.replace(/-/g, "_")}`;
+}

--- a/server-ts/src/mind/skill-tool.ts
+++ b/server-ts/src/mind/skill-tool.ts
@@ -1,3 +1,83 @@
+import type { Skill } from "../types.js";
+
+/**
+ * A JSON-schema object suitable for the Anthropic Messages API `tools` array.
+ */
+export type ToolDefinition = {
+  name: string;
+  description: string;
+  input_schema: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+};
+
 export function skillToToolName(skillName: string): string {
   return `run_${skillName.replace(/-/g, "_")}`;
+}
+
+export function skillToTool(skill: Skill): ToolDefinition {
+  return {
+    name: skillToToolName(skill.frontmatter.name),
+    description: skill.body.trim(),
+    input_schema: {
+      type: "object",
+      properties: {
+        context: {
+          type: "string",
+          description: "Free-form context describing why this skill should run",
+        },
+      },
+      required: [],
+    },
+  };
+}
+
+export function builtInTools(): ToolDefinition[] {
+  return [
+    {
+      name: "send_push",
+      description:
+        "Send a push notification to the employee. Use for time-sensitive, short messages worth interrupting for.",
+      input_schema: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Short title, <100 chars" },
+          body: { type: "string", description: "Body text" },
+          urgency: {
+            type: "string",
+            enum: ["low", "medium", "high"],
+            description: "Interrupt priority",
+          },
+        },
+        required: ["title", "body"],
+      },
+    },
+    {
+      name: "send_email",
+      description:
+        "Send an email to the employee. Use for longer, async messages such as morning briefs or summaries.",
+      input_schema: {
+        type: "object",
+        properties: {
+          subject: { type: "string" },
+          body_markdown: { type: "string" },
+        },
+        required: ["subject", "body_markdown"],
+      },
+    },
+    {
+      name: "defer_for_digest",
+      description:
+        "File a note for the employee's next return to the app. Use for anything not pressing.",
+      input_schema: {
+        type: "object",
+        properties: {
+          summary: { type: "string" },
+        },
+        required: ["summary"],
+      },
+    },
+  ];
 }

--- a/server-ts/src/mind/system-prompt.test.ts
+++ b/server-ts/src/mind/system-prompt.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../types.js";
+import { buildSystemPrompt } from "./system-prompt.js";
+
+const SKILL: Skill = {
+  frontmatter: {
+    name: "email-check",
+    triggers: [{ scheduled: "every weekday at 8am" }],
+    tools: [],
+    enabled: true,
+  },
+  body: "When triggered, read unread emails and surface urgent items.",
+  path: "/skills/email-check.md",
+};
+
+describe("buildSystemPrompt", () => {
+  it("includes employee name and company name", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "I am calm and attentive.",
+      mood: "focused",
+      rhythm: "morning person",
+      enabledSkills: [],
+      triageRules: "",
+    });
+    expect(prompt).toContain("alice");
+    expect(prompt).toContain("Acme");
+  });
+
+  it("embeds soul / mood / rhythm", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "MY_SOUL",
+      mood: "MY_MOOD",
+      rhythm: "MY_RHYTHM",
+      enabledSkills: [],
+      triageRules: "",
+    });
+    expect(prompt).toContain("MY_SOUL");
+    expect(prompt).toContain("MY_MOOD");
+    expect(prompt).toContain("MY_RHYTHM");
+  });
+
+  it("lists each enabled skill by name and tool", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "",
+      mood: "",
+      rhythm: "",
+      enabledSkills: [SKILL],
+      triageRules: "",
+    });
+    expect(prompt).toContain("email-check");
+    expect(prompt).toContain("run_email_check");
+  });
+
+  it("skips a skills block entirely when no skills are enabled", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "",
+      mood: "",
+      rhythm: "",
+      enabledSkills: [],
+      triageRules: "",
+    });
+    expect(prompt).not.toContain("<skills>");
+  });
+
+  it("includes triage rules when present", () => {
+    const prompt = buildSystemPrompt({
+      employeeName: "alice",
+      companyName: "Acme",
+      soul: "",
+      mood: "",
+      rhythm: "",
+      enabledSkills: [],
+      triageRules: "ALWAYS escalate urgent email",
+    });
+    expect(prompt).toContain("ALWAYS escalate urgent email");
+  });
+});

--- a/server-ts/src/mind/system-prompt.ts
+++ b/server-ts/src/mind/system-prompt.ts
@@ -1,0 +1,51 @@
+import type { Skill } from "../types.js";
+import { skillToToolName } from "./skill-tool.js";
+
+export type SystemPromptInputs = {
+  employeeName: string;
+  companyName: string;
+  soul: string;
+  mood: string;
+  rhythm: string;
+  enabledSkills: Skill[];
+  triageRules: string;
+};
+
+/**
+ * Build the system prompt for the mind. Output is stable for the same inputs,
+ * so it caches well via cache_control.
+ */
+export function buildSystemPrompt(inputs: SystemPromptInputs): string {
+  const { employeeName, companyName, soul, mood, rhythm, enabledSkills, triageRules } = inputs;
+
+  const skillsBlock =
+    enabledSkills.length === 0
+      ? ""
+      : `
+
+<skills>
+${enabledSkills
+  .map((s) => {
+    const tool = skillToToolName(s.frontmatter.name);
+    return `- ${s.frontmatter.name} (tool: ${tool})\n  ${s.body.trim()}`;
+  })
+  .join("\n\n")}
+</skills>`;
+
+  const triageBlock = triageRules.trim()
+    ? `
+
+<triage_rules>
+${triageRules.trim()}
+</triage_rules>`
+    : "";
+
+  return `You are Bolly, the AI coworker for ${employeeName} at ${companyName}.
+
+<persona>${soul}</persona>
+<mood>${mood}</mood>
+<rhythm>${rhythm}</rhythm>${skillsBlock}${triageBlock}
+
+Use the custom tools available to you when appropriate. You may reach out
+to ${employeeName} via send_push, send_email, or defer_for_digest.`;
+}

--- a/server-ts/src/mind/worker.test.ts
+++ b/server-ts/src/mind/worker.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Broadcaster } from "../events/broadcaster.js";
+import type { ServerEvent } from "../events/server-event.js";
+import { MockAnthropicClient } from "./mock-client.js";
+import { MindWorker } from "./worker.js";
+
+describe("MindWorker", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-worker-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("handles a chat message end-to-end and persists both turns", async () => {
+    const client = new MockAnthropicClient([
+      {
+        id: "msg_1",
+        role: "assistant",
+        model: "mock",
+        stop_reason: "end_turn",
+        content: [{ type: "text", text: "hi back" }],
+        usage: { input_tokens: 100, output_tokens: 10 },
+      },
+    ]);
+
+    const broadcaster = new Broadcaster();
+    const received: ServerEvent[] = [];
+    broadcaster.subscribe((e) => received.push(e));
+
+    const worker = new MindWorker({
+      client,
+      home,
+      slug: "alice",
+      chatId: "default",
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3.0,
+      pricePerMTokOut: 15.0,
+      broadcaster,
+    });
+
+    await worker.handleUserMessage("hello");
+
+    // Two broadcasts: AgentRunning (on start) and AgentStopped (on end),
+    // plus at least one ChatMessageCreated for the assistant reply.
+    const types = received.map((e) => e.type);
+    expect(types).toContain("agent_running");
+    expect(types).toContain("chat_message_created");
+    expect(types).toContain("agent_stopped");
+
+    // Conversation persisted: user turn + assistant turn.
+    const { loadConversation } = await import("../conversation/store.js");
+    const conv = await loadConversation(home, "alice", "default");
+    expect(conv.map((e) => e.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("tracks warm state: active after use, teardown-eligible after TTL", async () => {
+    const client = new MockAnthropicClient([]);
+    const worker = new MindWorker({
+      client,
+      home,
+      slug: "alice",
+      chatId: "default",
+      companyName: "Acme",
+      model: "mock",
+      pricePerMTokIn: 3.0,
+      pricePerMTokOut: 15.0,
+      broadcaster: new Broadcaster(),
+      warmTtlMs: 1000,
+    });
+
+    worker.touch(1_000_000);
+    expect(worker.isStaleAt(1_000_500)).toBe(false);
+    expect(worker.isStaleAt(1_002_001)).toBe(true);
+  });
+});

--- a/server-ts/src/mind/worker.ts
+++ b/server-ts/src/mind/worker.ts
@@ -61,6 +61,22 @@ export class MindWorker {
     broadcaster.emit({ type: "agent_running", instance_slug: slug, chat_id: chatId });
 
     try {
+      // Load the pre-append conversation snapshot FIRST, alongside other context.
+      // The user entry is appended below, after we have the snapshot we'll pass
+      // to runBudgetedMind — this avoids the user message appearing twice
+      // (once in the conversation history, once as the new userMessage).
+      const instDir = instanceDir(home, slug);
+      const [soul, mood, rhythm, enabledSkills, triageRules, settings, conversation] =
+        await Promise.all([
+          tryReadFile(join(instDir, "soul.md")),
+          tryReadFile(join(instDir, "mood.md")),
+          tryReadFile(join(instDir, "rhythm.json")),
+          loadSkills(home, slug, { enabledOnly: true }),
+          loadTriageRules(home, slug),
+          loadSettings(home, slug),
+          loadConversation(home, slug, chatId),
+        ]);
+
       const userEntry: ConversationEntry = {
         id: `msg_${Date.now()}_u`,
         role: "user",
@@ -82,19 +98,6 @@ export class MindWorker {
         chat_id: chatId,
         message: userMsg,
       });
-
-      // Assemble context
-      const instDir = instanceDir(home, slug);
-      const [soul, mood, rhythm, enabledSkills, triageRules, settings, conversation] =
-        await Promise.all([
-          tryReadFile(join(instDir, "soul.md")),
-          tryReadFile(join(instDir, "mood.md")),
-          tryReadFile(join(instDir, "rhythm.json")),
-          loadSkills(home, slug, { enabledOnly: true }),
-          loadTriageRules(home, slug),
-          loadSettings(home, slug),
-          loadConversation(home, slug, chatId),
-        ]);
 
       const systemPrompt = buildSystemPrompt({
         employeeName: slug,
@@ -123,7 +126,14 @@ export class MindWorker {
         // conversation and runBudgetedMind adds it as userMessage.
         conversation,
         userMessage: text,
-        executeTool: async (name) => `[${name} not wired in Plan 2]`,
+        // TODO(Plan4): wire real outreach delivery (send_push/email/digest) +
+        // cross-instance (emit_instance_event). Plan 2 ships with a loud stub
+        // so any production caller sees the placeholder in the assistant reply
+        // rather than silent failure.
+        executeTool: async (name) => {
+          console.warn(`[bolly] executeTool stub invoked for '${name}' — Plan 4 not yet wired`);
+          return `[bolly-stub] tool '${name}' is not wired yet. Plan 4 will implement it.`;
+        },
         maxIterations: 10,
       });
 

--- a/server-ts/src/mind/worker.ts
+++ b/server-ts/src/mind/worker.ts
@@ -1,0 +1,168 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { todayUtc } from "../budget/ledger.js";
+import { appendConversationEntry, loadConversation } from "../conversation/store.js";
+import type { ConversationEntry } from "../conversation/types.js";
+import type { Broadcaster } from "../events/broadcaster.js";
+import type { ChatMessage } from "../events/server-event.js";
+import { instanceDir } from "../paths.js";
+import { loadSettings } from "../settings/reader.js";
+import { loadSkills } from "../skills/loader.js";
+import { loadTriageRules } from "../triage/rules.js";
+import type { MindClient } from "./anthropic-client.js";
+import { runBudgetedMind } from "./budgeted-mind.js";
+import { builtInTools, skillToTool } from "./skill-tool.js";
+import { buildSystemPrompt } from "./system-prompt.js";
+
+const DEFAULT_WARM_TTL_MS = 10 * 60 * 1000;
+
+export type MindWorkerOptions = {
+  client: MindClient;
+  home: string;
+  slug: string;
+  chatId: string;
+  companyName: string;
+  model: string;
+  pricePerMTokIn: number;
+  pricePerMTokOut: number;
+  broadcaster: Broadcaster;
+  warmTtlMs?: number;
+};
+
+async function tryReadFile(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return "";
+    throw err;
+  }
+}
+
+export class MindWorker {
+  private lastActivityMs = Date.now();
+  private readonly warmTtlMs: number;
+
+  constructor(private readonly opts: MindWorkerOptions) {
+    this.warmTtlMs = opts.warmTtlMs ?? DEFAULT_WARM_TTL_MS;
+  }
+
+  touch(nowMs = Date.now()): void {
+    this.lastActivityMs = nowMs;
+  }
+
+  isStaleAt(nowMs: number): boolean {
+    return nowMs - this.lastActivityMs > this.warmTtlMs;
+  }
+
+  async handleUserMessage(text: string): Promise<void> {
+    const { home, slug, chatId, broadcaster } = this.opts;
+    this.touch();
+
+    broadcaster.emit({ type: "agent_running", instance_slug: slug, chat_id: chatId });
+
+    try {
+      const userEntry: ConversationEntry = {
+        id: `msg_${Date.now()}_u`,
+        role: "user",
+        content: [{ type: "text", text }],
+        ts: Date.now(),
+      };
+      await appendConversationEntry(home, slug, chatId, userEntry);
+
+      const userMsg: ChatMessage = {
+        id: userEntry.id,
+        role: "User",
+        content: text,
+        created_at: String(userEntry.ts),
+        kind: "Message",
+      };
+      broadcaster.emit({
+        type: "chat_message_created",
+        instance_slug: slug,
+        chat_id: chatId,
+        message: userMsg,
+      });
+
+      // Assemble context
+      const instDir = instanceDir(home, slug);
+      const [soul, mood, rhythm, enabledSkills, triageRules, settings, conversation] =
+        await Promise.all([
+          tryReadFile(join(instDir, "soul.md")),
+          tryReadFile(join(instDir, "mood.md")),
+          tryReadFile(join(instDir, "rhythm.json")),
+          loadSkills(home, slug, { enabledOnly: true }),
+          loadTriageRules(home, slug),
+          loadSettings(home, slug),
+          loadConversation(home, slug, chatId),
+        ]);
+
+      const systemPrompt = buildSystemPrompt({
+        employeeName: slug,
+        companyName: this.opts.companyName,
+        soul,
+        mood,
+        rhythm,
+        enabledSkills,
+        triageRules,
+      });
+
+      const tools = [...builtInTools(), ...enabledSkills.map(skillToTool)];
+
+      const outcome = await runBudgetedMind({
+        client: this.opts.client,
+        home,
+        slug,
+        day: todayUtc(),
+        capUsd: settings.daily_budget_usd,
+        model: this.opts.model,
+        pricePerMTokIn: this.opts.pricePerMTokIn,
+        pricePerMTokOut: this.opts.pricePerMTokOut,
+        systemPrompt,
+        tools,
+        // Don't include the just-appended user entry twice — pass the pre-append
+        // conversation and runBudgetedMind adds it as userMessage.
+        conversation,
+        userMessage: text,
+        executeTool: async (name) => `[${name} not wired in Plan 2]`,
+        maxIterations: 10,
+      });
+
+      if ("downgraded" in outcome && outcome.downgraded) {
+        broadcaster.emit({ type: "agent_stopped", instance_slug: slug, chat_id: chatId });
+        return;
+      }
+
+      // At this point outcome is MindFullTurnResult (downgraded variant handled above)
+      const result = outcome as import("./budgeted-mind.js").BudgetedMindResult & {
+        downgraded?: false;
+        assistantContent: import("../conversation/types.js").ContentBlock[];
+        finalText: string;
+      };
+
+      const assistantEntry: ConversationEntry = {
+        id: `msg_${Date.now()}_a`,
+        role: "assistant",
+        content: result.assistantContent,
+        ts: Date.now(),
+        model: this.opts.model,
+      };
+      await appendConversationEntry(home, slug, chatId, assistantEntry);
+
+      broadcaster.emit({
+        type: "chat_message_created",
+        instance_slug: slug,
+        chat_id: chatId,
+        message: {
+          id: assistantEntry.id,
+          role: "Assistant",
+          content: result.finalText,
+          created_at: String(assistantEntry.ts),
+          kind: "Message",
+          model: this.opts.model,
+        },
+      });
+    } finally {
+      broadcaster.emit({ type: "agent_stopped", instance_slug: slug, chat_id: chatId });
+    }
+  }
+}

--- a/server-ts/src/outreach/audit.test.ts
+++ b/server-ts/src/outreach/audit.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OutreachEntry } from "../types.js";
+import { appendOutreach, readRecentOutreach } from "./audit.js";
+
+function entry(id: string, ts: number, title = `event-${id}`): OutreachEntry {
+  return {
+    id,
+    ts,
+    channel: "push",
+    title,
+    urgency: "medium",
+    delivered: true,
+    dedup_suppressed: false,
+  };
+}
+
+describe("appendOutreach + readRecentOutreach", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-outreach-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns an empty list when the file is absent", async () => {
+    const entries = await readRecentOutreach(home, "alice", 10);
+    expect(entries).toEqual([]);
+  });
+
+  it("appends entries as JSON lines", async () => {
+    await appendOutreach(home, "alice", entry("a", 100));
+    await appendOutreach(home, "alice", entry("b", 200));
+    const entries = await readRecentOutreach(home, "alice", 10);
+    expect(entries.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("returns only the last N entries, newest last", async () => {
+    for (let i = 0; i < 5; i++) {
+      await appendOutreach(home, "alice", entry(`e${i}`, 1000 + i));
+    }
+    const entries = await readRecentOutreach(home, "alice", 3);
+    expect(entries.map((e) => e.id)).toEqual(["e2", "e3", "e4"]);
+  });
+
+  it("tolerates and skips malformed lines", async () => {
+    // Write a broken line directly, then a good one through the API
+    const { appendFile, mkdir } = await import("node:fs/promises");
+    const dir = join(home, "instances", "alice");
+    await mkdir(dir, { recursive: true });
+    await appendFile(join(dir, "outreach.jsonl"), "{ not valid json\n");
+    await appendOutreach(home, "alice", entry("good", 500));
+    const entries = await readRecentOutreach(home, "alice", 10);
+    expect(entries.map((e) => e.id)).toEqual(["good"]);
+  });
+});

--- a/server-ts/src/outreach/audit.ts
+++ b/server-ts/src/outreach/audit.ts
@@ -1,0 +1,48 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { outreachFile } from "../paths.js";
+import { type OutreachEntry, OutreachEntrySchema } from "../types.js";
+
+export async function appendOutreach(
+  home: string,
+  slug: string,
+  entry: OutreachEntry,
+): Promise<void> {
+  const path = outreachFile(home, slug);
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${JSON.stringify(entry)}\n`);
+}
+
+/**
+ * Read the last N outreach entries, oldest-first within the returned slice.
+ * Returns [] if the file does not exist. Malformed lines are skipped silently.
+ */
+export async function readRecentOutreach(
+  home: string,
+  slug: string,
+  limit: number,
+): Promise<OutreachEntry[]> {
+  const path = outreachFile(home, slug);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const lines = raw.split("\n").filter((l) => l.length > 0);
+  const start = Math.max(0, lines.length - limit);
+  const slice = lines.slice(start);
+
+  const result: OutreachEntry[] = [];
+  for (const line of slice) {
+    try {
+      const parsed = JSON.parse(line);
+      result.push(OutreachEntrySchema.parse(parsed));
+    } catch {
+      // malformed line — skip
+    }
+  }
+  return result;
+}

--- a/server-ts/src/paths.test.ts
+++ b/server-ts/src/paths.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  bollyHome,
+  budgetDailyFile,
+  budgetDir,
+  chatDir,
+  conversationFile,
+  instanceDir,
+  outreachFile,
+  sharedChannelDir,
+  sharedDir,
+  sharedInstancesFile,
+  skillFile,
+  skillsDir,
+  triageFile,
+} from "./paths.js";
+
+describe("paths", () => {
+  const home = "/tmp/bolly-test";
+
+  it("bollyHome returns the passed root", () => {
+    expect(bollyHome(home)).toBe(home);
+  });
+
+  it("instanceDir joins home + instances + slug", () => {
+    expect(instanceDir(home, "alice")).toBe("/tmp/bolly-test/instances/alice");
+  });
+
+  it("chatDir nests under instance/chats/chatId", () => {
+    expect(chatDir(home, "alice", "default")).toBe("/tmp/bolly-test/instances/alice/chats/default");
+  });
+
+  it("conversationFile lives inside chatDir", () => {
+    expect(conversationFile(home, "alice", "default")).toBe(
+      "/tmp/bolly-test/instances/alice/chats/default/conversation.json",
+    );
+  });
+
+  it("skillsDir is instances/{slug}/skills", () => {
+    expect(skillsDir(home, "alice")).toBe("/tmp/bolly-test/instances/alice/skills");
+  });
+
+  it("skillFile suffixes .md", () => {
+    expect(skillFile(home, "alice", "email-check")).toBe(
+      "/tmp/bolly-test/instances/alice/skills/email-check.md",
+    );
+  });
+
+  it("triageFile is instances/{slug}/triage.md", () => {
+    expect(triageFile(home, "alice")).toBe("/tmp/bolly-test/instances/alice/triage.md");
+  });
+
+  it("budgetDir is instances/{slug}/budget", () => {
+    expect(budgetDir(home, "alice")).toBe("/tmp/bolly-test/instances/alice/budget");
+  });
+
+  it("budgetDailyFile uses YYYY-MM-DD.json", () => {
+    expect(budgetDailyFile(home, "alice", "2026-04-22")).toBe(
+      "/tmp/bolly-test/instances/alice/budget/2026-04-22.json",
+    );
+  });
+
+  it("outreachFile is instances/{slug}/outreach.jsonl", () => {
+    expect(outreachFile(home, "alice")).toBe("/tmp/bolly-test/instances/alice/outreach.jsonl");
+  });
+
+  it("sharedDir is home/shared", () => {
+    expect(sharedDir(home)).toBe("/tmp/bolly-test/shared");
+  });
+
+  it("sharedChannelDir is home/shared/channel", () => {
+    expect(sharedChannelDir(home)).toBe("/tmp/bolly-test/shared/channel");
+  });
+
+  it("sharedInstancesFile is home/shared/instances.json", () => {
+    expect(sharedInstancesFile(home)).toBe("/tmp/bolly-test/shared/instances.json");
+  });
+});

--- a/server-ts/src/paths.ts
+++ b/server-ts/src/paths.ts
@@ -1,0 +1,57 @@
+import { join } from "node:path";
+
+export function bollyHome(home: string): string {
+  return home;
+}
+
+export function instanceDir(home: string, slug: string): string {
+  return join(home, "instances", slug);
+}
+
+export function chatDir(home: string, slug: string, chatId: string): string {
+  return join(instanceDir(home, slug), "chats", chatId);
+}
+
+export function conversationFile(home: string, slug: string, chatId: string): string {
+  return join(chatDir(home, slug, chatId), "conversation.json");
+}
+
+export function skillsDir(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "skills");
+}
+
+export function skillFile(home: string, slug: string, name: string): string {
+  return join(skillsDir(home, slug), `${name}.md`);
+}
+
+export function triageFile(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "triage.md");
+}
+
+export function budgetDir(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "budget");
+}
+
+export function budgetDailyFile(home: string, slug: string, day: string): string {
+  return join(budgetDir(home, slug), `${day}.json`);
+}
+
+export function outreachFile(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "outreach.jsonl");
+}
+
+export function settingsFile(home: string, slug: string): string {
+  return join(instanceDir(home, slug), "settings.toml");
+}
+
+export function sharedDir(home: string): string {
+  return join(home, "shared");
+}
+
+export function sharedChannelDir(home: string): string {
+  return join(sharedDir(home), "channel");
+}
+
+export function sharedInstancesFile(home: string): string {
+  return join(sharedDir(home), "instances.json");
+}

--- a/server-ts/src/settings/reader.test.ts
+++ b/server-ts/src/settings/reader.test.ts
@@ -1,0 +1,56 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS, loadSettings } from "./reader.js";
+
+describe("loadSettings", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-settings-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns DEFAULT_SETTINGS when settings.toml is missing", async () => {
+    const s = await loadSettings(home, "alice");
+    expect(s).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("merges user-provided fields over defaults", async () => {
+    const dir = join(home, "instances", "alice");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "settings.toml"),
+      `daily_budget_usd = 5.0
+
+[quiet_hours]
+start = "23:00"
+end = "08:00"
+
+[push]
+daily_max = 10
+`,
+    );
+    const s = await loadSettings(home, "alice");
+    expect(s.daily_budget_usd).toBe(5.0);
+    expect(s.quiet_hours.start).toBe("23:00");
+    expect(s.quiet_hours.end).toBe("08:00");
+    expect(s.push.daily_max).toBe(10);
+    // Defaults preserved for unspecified fields
+    expect(s.push.enabled).toBe(true);
+    expect(s.email.enabled).toBe(DEFAULT_SETTINGS.email.enabled);
+  });
+
+  it("DEFAULT_SETTINGS has a 2.00 daily budget", () => {
+    expect(DEFAULT_SETTINGS.daily_budget_usd).toBe(2.0);
+  });
+
+  it("DEFAULT_SETTINGS has 22:00-07:00 quiet hours", () => {
+    expect(DEFAULT_SETTINGS.quiet_hours.start).toBe("22:00");
+    expect(DEFAULT_SETTINGS.quiet_hours.end).toBe("07:00");
+  });
+});

--- a/server-ts/src/settings/reader.ts
+++ b/server-ts/src/settings/reader.ts
@@ -28,9 +28,10 @@ const SettingsSchema = z.object({
 // z.output gives the fully-resolved shape after defaults are applied
 export type Settings = z.output<typeof SettingsSchema>;
 
-// Cast required: TS infers the input type from parse({}); at runtime zod fills
-// all defaults so the cast is sound.
-export const DEFAULT_SETTINGS = SettingsSchema.parse({}) as unknown as Settings;
+// readToml<T> infers T from ZodSchema<T> as zod's *input* type, so the parsed
+// result (which is actually z.output) needs a local cast. The `if (!result)`
+// check handles null explicitly so the cast is never applied to a null value.
+export const DEFAULT_SETTINGS: Settings = SettingsSchema.parse({}) as Settings;
 
 /**
  * Read the instance's settings.toml; fall back to DEFAULT_SETTINGS if
@@ -39,5 +40,6 @@ export const DEFAULT_SETTINGS = SettingsSchema.parse({}) as unknown as Settings;
  */
 export async function loadSettings(home: string, slug: string): Promise<Settings> {
   const result = await readToml(settingsFile(home, slug), SettingsSchema);
-  return (result as unknown as Settings) ?? DEFAULT_SETTINGS;
+  if (!result) return DEFAULT_SETTINGS;
+  return result as Settings;
 }

--- a/server-ts/src/settings/reader.ts
+++ b/server-ts/src/settings/reader.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { settingsFile } from "../paths.js";
+import { readToml } from "../toml-file.js";
+
+const SettingsSchema = z.object({
+  daily_budget_usd: z.number().positive().default(2.0),
+  quiet_hours: z
+    .object({
+      start: z.string().default("22:00"),
+      end: z.string().default("07:00"),
+    })
+    .default({}),
+  push: z
+    .object({
+      enabled: z.boolean().default(true),
+      daily_max: z.number().int().positive().default(5),
+    })
+    .default({}),
+  email: z
+    .object({
+      enabled: z.boolean().default(true),
+      address: z.string().optional(),
+      daily_max: z.number().int().positive().default(2),
+    })
+    .default({}),
+});
+
+// z.output gives the fully-resolved shape after defaults are applied
+export type Settings = z.output<typeof SettingsSchema>;
+
+// Cast required: TS infers the input type from parse({}); at runtime zod fills
+// all defaults so the cast is sound.
+export const DEFAULT_SETTINGS = SettingsSchema.parse({}) as unknown as Settings;
+
+/**
+ * Read the instance's settings.toml; fall back to DEFAULT_SETTINGS if
+ * the file does not exist. User-provided fields are merged over defaults
+ * by zod's schema default propagation.
+ */
+export async function loadSettings(home: string, slug: string): Promise<Settings> {
+  const result = await readToml(settingsFile(home, slug), SettingsSchema);
+  return (result as unknown as Settings) ?? DEFAULT_SETTINGS;
+}

--- a/server-ts/src/skills/loader.test.ts
+++ b/server-ts/src/skills/loader.test.ts
@@ -1,0 +1,58 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadSkills } from "./loader.js";
+
+async function seed(home: string, slug: string, name: string, body: string): Promise<void> {
+  const dir = join(home, "instances", slug, "skills");
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, `${name}.md`), body);
+}
+
+describe("loadSkills", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-skills-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns an empty array when no skills directory exists", async () => {
+    const skills = await loadSkills(home, "alice");
+    expect(skills).toEqual([]);
+  });
+
+  it("loads all .md files from the skills directory", async () => {
+    await seed(home, "alice", "one", "---\nname: one\n---\n\nbody one");
+    await seed(home, "alice", "two", "---\nname: two\n---\n\nbody two");
+    const skills = await loadSkills(home, "alice");
+    const names = skills.map((s) => s.frontmatter.name).sort();
+    expect(names).toEqual(["one", "two"]);
+  });
+
+  it("skips non-.md files", async () => {
+    await seed(home, "alice", "real", "---\nname: real\n---\n\nbody");
+    await writeFile(join(home, "instances", "alice", "skills", "readme.txt"), "not a skill");
+    const skills = await loadSkills(home, "alice");
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.frontmatter.name).toBe("real");
+  });
+
+  it("filters out disabled skills when enabledOnly=true", async () => {
+    await seed(home, "alice", "on", "---\nname: on\nenabled: true\n---\n\nbody");
+    await seed(home, "alice", "off", "---\nname: off\nenabled: false\n---\n\nbody");
+    const enabled = await loadSkills(home, "alice", { enabledOnly: true });
+    expect(enabled.map((s) => s.frontmatter.name)).toEqual(["on"]);
+  });
+
+  it("returns all skills when enabledOnly omitted", async () => {
+    await seed(home, "alice", "on", "---\nname: on\nenabled: true\n---\n\nbody");
+    await seed(home, "alice", "off", "---\nname: off\nenabled: false\n---\n\nbody");
+    const all = await loadSkills(home, "alice");
+    expect(all).toHaveLength(2);
+  });
+});

--- a/server-ts/src/skills/loader.ts
+++ b/server-ts/src/skills/loader.ts
@@ -1,0 +1,39 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { skillsDir } from "../paths.js";
+import type { Skill } from "../types.js";
+import { parseSkill } from "./parse.js";
+
+export type LoadSkillsOptions = {
+  enabledOnly?: boolean;
+};
+
+/**
+ * Load all skill .md files from an instance's skills directory.
+ * Returns [] if the directory does not exist.
+ */
+export async function loadSkills(
+  home: string,
+  slug: string,
+  opts: LoadSkillsOptions = {},
+): Promise<Skill[]> {
+  const dir = skillsDir(home, slug);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const results: Skill[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".md")) continue;
+    const full = join(dir, name);
+    const raw = await readFile(full, "utf8");
+    const skill = parseSkill(raw, full);
+    if (opts.enabledOnly && !skill.frontmatter.enabled) continue;
+    results.push(skill);
+  }
+  return results;
+}

--- a/server-ts/src/skills/parse.test.ts
+++ b/server-ts/src/skills/parse.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { parseSkill } from "./parse.js";
+
+const VALID_SKILL = `---
+name: email-morning-check
+created: 2026-04-22
+triggers:
+  - scheduled: "every weekday at 8am"
+  - event: "email arrives with 'urgent' in subject"
+tools:
+  - read_email
+  - send_push
+enabled: true
+---
+
+When triggered, read unread emails since last check.
+Summarize anything the user would care about.
+`;
+
+describe("parseSkill", () => {
+  it("parses a well-formed skill into frontmatter + body", () => {
+    const skill = parseSkill(VALID_SKILL, "/instances/alice/skills/email.md");
+    expect(skill.frontmatter.name).toBe("email-morning-check");
+    expect(skill.frontmatter.tools).toEqual(["read_email", "send_push"]);
+    expect(skill.frontmatter.enabled).toBe(true);
+    expect(skill.frontmatter.triggers).toHaveLength(2);
+    expect(skill.body).toContain("When triggered");
+    expect(skill.path).toBe("/instances/alice/skills/email.md");
+  });
+
+  it("applies defaults for missing optional fields", () => {
+    const minimal = `---
+name: minimal
+---
+
+body here
+`;
+    const skill = parseSkill(minimal, "/x.md");
+    expect(skill.frontmatter.enabled).toBe(true);
+    expect(skill.frontmatter.tools).toEqual([]);
+    expect(skill.frontmatter.triggers).toEqual([]);
+  });
+
+  it("throws when frontmatter is absent", () => {
+    expect(() => parseSkill("no frontmatter here", "/x.md")).toThrow(/frontmatter/i);
+  });
+
+  it("throws when the required name field is missing", () => {
+    const bad = `---
+description: anonymous skill
+---
+
+body
+`;
+    expect(() => parseSkill(bad, "/x.md")).toThrow();
+  });
+
+  it("respects enabled: false", () => {
+    const disabled = `---
+name: sleeping
+enabled: false
+---
+
+not right now
+`;
+    const skill = parseSkill(disabled, "/x.md");
+    expect(skill.frontmatter.enabled).toBe(false);
+  });
+});

--- a/server-ts/src/skills/parse.ts
+++ b/server-ts/src/skills/parse.ts
@@ -1,0 +1,29 @@
+import matter from "gray-matter";
+import { type Skill, SkillFrontmatterSchema } from "../types.js";
+
+/**
+ * Parse a skill file (YAML frontmatter + markdown body) into a Skill.
+ * Throws if frontmatter is missing or does not match the schema.
+ */
+export function parseSkill(contents: string, path: string): Skill {
+  if (!contents.trimStart().startsWith("---")) {
+    throw new Error(`skill at ${path} is missing YAML frontmatter`);
+  }
+
+  const { data, content } = matter(contents);
+
+  // gray-matter parses YAML dates as JS Date objects; coerce to ISO string so
+  // the schema's z.string().optional() validation succeeds.
+  const normalized =
+    data.created instanceof Date
+      ? { ...data, created: data.created.toISOString().slice(0, 10) }
+      : data;
+
+  const frontmatter = SkillFrontmatterSchema.parse(normalized);
+
+  return {
+    frontmatter,
+    body: content.trimStart(),
+    path,
+  };
+}

--- a/server-ts/src/toml-file.test.ts
+++ b/server-ts/src/toml-file.test.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { readToml } from "./toml-file.js";
+
+const ConfigSchema = z.object({
+  name: z.string(),
+  nested: z.object({ value: z.number() }),
+});
+
+describe("readToml", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "bolly-toml-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("parses a valid TOML file through the schema", async () => {
+    const f = join(dir, "config.toml");
+    await writeFile(f, 'name = "alice"\n[nested]\nvalue = 42\n');
+    const result = await readToml(f, ConfigSchema);
+    expect(result).toEqual({ name: "alice", nested: { value: 42 } });
+  });
+
+  it("returns null when the file is missing", async () => {
+    const f = join(dir, "missing.toml");
+    const result = await readToml(f, ConfigSchema);
+    expect(result).toBeNull();
+  });
+
+  it("throws when the TOML is malformed", async () => {
+    const f = join(dir, "broken.toml");
+    await writeFile(f, "not = [ valid");
+    await expect(readToml(f, ConfigSchema)).rejects.toThrow(/parse/i);
+  });
+});

--- a/server-ts/src/toml-file.ts
+++ b/server-ts/src/toml-file.ts
@@ -1,0 +1,26 @@
+import { readFile } from "node:fs/promises";
+import { parse as parseToml } from "smol-toml";
+import type { ZodSchema } from "zod";
+
+/**
+ * Read a TOML file and validate it against a zod schema.
+ * Returns null if the file does not exist.
+ */
+export async function readToml<T>(path: string, schema: ZodSchema<T>): Promise<T | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseToml(raw);
+  } catch (err) {
+    throw new Error(`failed to parse TOML at ${path}: ${(err as Error).message}`);
+  }
+
+  return schema.parse(parsed);
+}

--- a/server-ts/src/triage/prompt.test.ts
+++ b/server-ts/src/triage/prompt.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "../types.js";
+import { buildTriagePrompt } from "./prompt.js";
+
+const EVENT: Event = {
+  id: "01JKM000000000000000000000",
+  user_id: "alice",
+  source: "email",
+  ts: 1714000000000,
+  payload: { subject: "Q2 review", from: "boss@corp.com" },
+};
+
+describe("buildTriagePrompt", () => {
+  it("includes soul, mood, budget, triage rules, and the event", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "Bolly is calm and attentive.",
+      mood: "focused",
+      budgetState: "ok",
+      dollarsSpent: 0.42,
+      capUsd: 2.0,
+      triageRules: "# rules\n- urgent email -> escalate",
+      event: EVENT,
+      recentOutreach: [],
+    });
+
+    expect(prompt).toContain("<soul>Bolly is calm and attentive.</soul>");
+    expect(prompt).toContain("<mood>focused</mood>");
+    expect(prompt).toContain("0.42/2.00");
+    expect(prompt).toContain("ok");
+    expect(prompt).toContain("urgent email -> escalate");
+    expect(prompt).toContain("Q2 review");
+  });
+
+  it("adds tightening directive when state is tight", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "tight",
+      dollarsSpent: 1.5,
+      capUsd: 2.0,
+      triageRules: "",
+      event: EVENT,
+      recentOutreach: [],
+    });
+    expect(prompt).toContain("Only escalate if truly urgent");
+  });
+
+  it("adds suppression directive when state is suppressed", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "suppressed",
+      dollarsSpent: 2.0,
+      capUsd: 2.0,
+      triageRules: "",
+      event: EVENT,
+      recentOutreach: [],
+    });
+    expect(prompt).toContain("budget cap reached");
+  });
+
+  it("includes the last N outreach entries for self-regulation context", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "ok",
+      dollarsSpent: 0,
+      capUsd: 2.0,
+      triageRules: "",
+      event: EVENT,
+      recentOutreach: [
+        { channel: "push", title: "reminder", ts: 1713999999000, urgency: "medium" },
+        { channel: "email", title: "digest", ts: 1713999998000, urgency: "low" },
+      ],
+    });
+    expect(prompt).toContain("push: reminder");
+    expect(prompt).toContain("email: digest");
+  });
+
+  it("asks for the single-line response format", () => {
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "ok",
+      dollarsSpent: 0,
+      capUsd: 2.0,
+      triageRules: "",
+      event: EVENT,
+      recentOutreach: [],
+    });
+    expect(prompt).toMatch(/DECISION=.*REASON=/);
+  });
+
+  it("truncates large event payloads", () => {
+    const bigEvent: Event = {
+      ...EVENT,
+      payload: { body: "x".repeat(5000) },
+    };
+    const prompt = buildTriagePrompt({
+      soulSnippet: "",
+      mood: "",
+      budgetState: "ok",
+      dollarsSpent: 0,
+      capUsd: 2.0,
+      triageRules: "",
+      event: bigEvent,
+      recentOutreach: [],
+    });
+    expect(prompt.length).toBeLessThan(6000);
+    expect(prompt).toContain("[truncated]");
+  });
+});

--- a/server-ts/src/triage/prompt.ts
+++ b/server-ts/src/triage/prompt.ts
@@ -1,7 +1,7 @@
-import type { BudgetState, Event } from "../types.js";
+import type { BudgetState, Event, OutreachChannel } from "../types.js";
 
 export type OutreachHint = {
-  channel: "push" | "email" | "digest";
+  channel: OutreachChannel;
   title: string;
   ts: number;
   urgency: "low" | "medium" | "high";

--- a/server-ts/src/triage/prompt.ts
+++ b/server-ts/src/triage/prompt.ts
@@ -1,0 +1,72 @@
+import type { BudgetState, Event } from "../types.js";
+
+export type OutreachHint = {
+  channel: "push" | "email" | "digest";
+  title: string;
+  ts: number;
+  urgency: "low" | "medium" | "high";
+};
+
+export type TriagePromptInputs = {
+  soulSnippet: string;
+  mood: string;
+  budgetState: BudgetState;
+  dollarsSpent: number;
+  capUsd: number;
+  triageRules: string;
+  event: Event;
+  recentOutreach: OutreachHint[];
+};
+
+const EVENT_PAYLOAD_MAX = 1024;
+
+function truncateJson(value: unknown, limit: number): string {
+  const serialized = JSON.stringify(value);
+  if (serialized.length <= limit) return serialized;
+  return `${serialized.slice(0, limit)}[truncated]`;
+}
+
+function budgetDirective(state: BudgetState): string {
+  if (state === "tight") return "Only escalate if truly urgent.";
+  if (state === "suppressed") return "budget cap reached — prefer digest.";
+  return "";
+}
+
+export function buildTriagePrompt(inputs: TriagePromptInputs): string {
+  const {
+    soulSnippet,
+    mood,
+    budgetState,
+    dollarsSpent,
+    capUsd,
+    triageRules,
+    event,
+    recentOutreach,
+  } = inputs;
+
+  const outreachLines = recentOutreach
+    .map((o) => `  - ${o.channel}: ${o.title} (${o.urgency})`)
+    .join("\n");
+
+  const directive = budgetDirective(budgetState);
+
+  return `You are the triage layer for Bolly. Decide: ignore | digest | escalate.
+
+<soul>${soulSnippet}</soul>
+<mood>${mood}</mood>
+<budget_state>${dollarsSpent.toFixed(2)}/${capUsd.toFixed(2)} — ${budgetState}</budget_state>
+${directive ? `<directive>${directive}</directive>\n` : ""}<triage_rules>
+${triageRules}
+</triage_rules>
+
+<recent_outreach>
+${outreachLines || "  (none)"}
+</recent_outreach>
+
+<event source="${event.source}" id="${event.id}" ts="${event.ts}">
+${truncateJson(event.payload, EVENT_PAYLOAD_MAX)}
+</event>
+
+Respond with exactly one line:
+DECISION=<ignore|digest|escalate> REASON=<short sentence>`;
+}

--- a/server-ts/src/triage/rules.test.ts
+++ b/server-ts/src/triage/rules.test.ts
@@ -1,0 +1,35 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_TRIAGE_TEMPLATE, loadTriageRules } from "./rules.js";
+
+describe("loadTriageRules", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "bolly-triage-"));
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns the default template when triage.md is missing", async () => {
+    const rules = await loadTriageRules(home, "alice");
+    expect(rules).toBe(DEFAULT_TRIAGE_TEMPLATE);
+  });
+
+  it("returns the raw file contents when triage.md exists", async () => {
+    const dir = join(home, "instances", "alice");
+    await mkdir(dir, { recursive: true });
+    const body = "# My rules\n\nAlways digest newsletters.";
+    await writeFile(join(dir, "triage.md"), body);
+    const rules = await loadTriageRules(home, "alice");
+    expect(rules).toBe(body);
+  });
+
+  it("DEFAULT_TRIAGE_TEMPLATE contains the word Default", () => {
+    expect(DEFAULT_TRIAGE_TEMPLATE).toMatch(/default/i);
+  });
+});

--- a/server-ts/src/triage/rules.ts
+++ b/server-ts/src/triage/rules.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import { triageFile } from "../paths.js";
+
+export const DEFAULT_TRIAGE_TEMPLATE = `# Triage rules
+
+Default: unless matched below, ignore.
+
+## Always escalate
+- User sent a message in the app
+- Email or event marked urgent
+- A skill I installed explicitly asks for escalation
+
+## Always digest
+- Newsletter emails
+- Notification-only emails
+- Calendar changes in the past
+
+## Quiet hours
+- Between 22:00 and 07:00: only escalate if "emergency" in subject
+`;
+
+/**
+ * Read the user's triage rules file. Returns the default template when
+ * the file is missing — the mind will overwrite it once the user expresses
+ * preferences.
+ */
+export async function loadTriageRules(home: string, slug: string): Promise<string> {
+  try {
+    return await readFile(triageFile(home, slug), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return DEFAULT_TRIAGE_TEMPLATE;
+    }
+    throw err;
+  }
+}

--- a/server-ts/src/types.test.ts
+++ b/server-ts/src/types.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { BudgetStateSchema, EventSourceSchema, TriageDecisionSchema } from "./types.js";
+
+describe("EventSourceSchema", () => {
+  it("accepts the eight known sources", () => {
+    const sources = [
+      "user_msg",
+      "user_activity",
+      "email",
+      "calendar",
+      "scheduled",
+      "idle",
+      "skill_emit",
+      "instance_emit",
+    ];
+    for (const s of sources) {
+      expect(EventSourceSchema.parse(s)).toBe(s);
+    }
+  });
+
+  it("rejects an unknown source", () => {
+    expect(() => EventSourceSchema.parse("bogus")).toThrow();
+  });
+});
+
+describe("TriageDecisionSchema", () => {
+  it("accepts ignore, digest, escalate", () => {
+    for (const d of ["ignore", "digest", "escalate"]) {
+      expect(TriageDecisionSchema.parse(d)).toBe(d);
+    }
+  });
+
+  it("rejects any other value", () => {
+    expect(() => TriageDecisionSchema.parse("skip")).toThrow();
+  });
+});
+
+describe("BudgetStateSchema", () => {
+  it("accepts ok, tight, suppressed", () => {
+    for (const s of ["ok", "tight", "suppressed"]) {
+      expect(BudgetStateSchema.parse(s)).toBe(s);
+    }
+  });
+});

--- a/server-ts/src/types.test.ts
+++ b/server-ts/src/types.test.ts
@@ -41,4 +41,8 @@ describe("BudgetStateSchema", () => {
       expect(BudgetStateSchema.parse(s)).toBe(s);
     }
   });
+
+  it("rejects any other value", () => {
+    expect(() => BudgetStateSchema.parse("paused")).toThrow();
+  });
 });

--- a/server-ts/src/types.ts
+++ b/server-ts/src/types.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+export const EventSourceSchema = z.enum([
+  "user_msg",
+  "user_activity",
+  "email",
+  "calendar",
+  "scheduled",
+  "idle",
+  "skill_emit",
+  "instance_emit",
+]);
+export type EventSource = z.infer<typeof EventSourceSchema>;
+
+export const EventSchema = z.object({
+  id: z.string().min(1),
+  user_id: z.string().min(1),
+  source: EventSourceSchema,
+  ts: z.number().int().nonnegative(),
+  payload: z.record(z.unknown()).default({}),
+  skill_hint: z.string().optional(),
+});
+export type Event = z.infer<typeof EventSchema>;
+
+export const TriageDecisionSchema = z.enum(["ignore", "digest", "escalate"]);
+export type TriageDecision = z.infer<typeof TriageDecisionSchema>;
+
+export const TriageOutcomeSchema = z.object({
+  decision: TriageDecisionSchema,
+  reason: z.string(),
+});
+export type TriageOutcome = z.infer<typeof TriageOutcomeSchema>;
+
+export const BudgetStateSchema = z.enum(["ok", "tight", "suppressed"]);
+export type BudgetState = z.infer<typeof BudgetStateSchema>;
+
+export const BudgetDailySchema = z.object({
+  day: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  calls: z.number().int().nonnegative().default(0),
+  tokens_in: z.number().int().nonnegative().default(0),
+  tokens_out: z.number().int().nonnegative().default(0),
+  dollars_spent: z.number().nonnegative().default(0),
+  cap_usd: z.number().positive(),
+  state: BudgetStateSchema.default("ok"),
+});
+export type BudgetDaily = z.infer<typeof BudgetDailySchema>;
+
+export const SkillFrontmatterSchema = z.object({
+  name: z.string().min(1),
+  created: z.string().optional(),
+  triggers: z.array(z.record(z.unknown())).default([]),
+  tools: z.array(z.string()).default([]),
+  enabled: z.boolean().default(true),
+});
+export type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;
+
+export const SkillSchema = z.object({
+  frontmatter: SkillFrontmatterSchema,
+  body: z.string(),
+  path: z.string(),
+});
+export type Skill = z.infer<typeof SkillSchema>;
+
+export const OutreachChannelSchema = z.enum(["push", "email", "digest"]);
+export type OutreachChannel = z.infer<typeof OutreachChannelSchema>;
+
+export const OutreachEntrySchema = z.object({
+  id: z.string().min(1),
+  ts: z.number().int().nonnegative(),
+  channel: OutreachChannelSchema,
+  title: z.string(),
+  body: z.string().optional(),
+  urgency: z.enum(["low", "medium", "high"]).default("medium"),
+  delivered: z.boolean(),
+  dedup_suppressed: z.boolean().default(false),
+});
+export type OutreachEntry = z.infer<typeof OutreachEntrySchema>;

--- a/server-ts/src/types.ts
+++ b/server-ts/src/types.ts
@@ -40,7 +40,7 @@ export const BudgetDailySchema = z.object({
   tokens_in: z.number().int().nonnegative().default(0),
   tokens_out: z.number().int().nonnegative().default(0),
   dollars_spent: z.number().nonnegative().default(0),
-  cap_usd: z.number().positive(),
+  cap_usd: z.number().positive().max(10_000),
   state: BudgetStateSchema.default("ok"),
 });
 export type BudgetDaily = z.infer<typeof BudgetDailySchema>;
@@ -68,7 +68,7 @@ export const OutreachEntrySchema = z.object({
   id: z.string().min(1),
   ts: z.number().int().nonnegative(),
   channel: OutreachChannelSchema,
-  title: z.string(),
+  title: z.string().min(1),
   body: z.string().optional(),
   urgency: z.enum(["low", "medium", "high"]).default("medium"),
   delivered: z.boolean(),

--- a/server-ts/tsconfig.json
+++ b/server-ts/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"]
+}

--- a/server-ts/vitest.config.ts
+++ b/server-ts/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    passWithNoTests: true,
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Opens the Bolly v1.0 rewrite effort. Three things land together:

1. **Full architectural spec** — event-driven three-tier heartbeat (events → Haiku triage → Messages API mind loop), NL-configured skills replacing \`ChildAgentConfig\`, per-employee budget ledger, \`shared/\` directory for cross-instance coordination. Self-hosted only, Anthropic Messages API directly (not Managed Agents — Bolly only uses custom tools, and ZDR is confirmed for \`/v1/messages\`).

2. **Plan 1 of 6** (Foundations, 18 tasks) — 10-week path from the current Rust server to a TS v1.0 rewrite. This PR starts execution.

3. **Product pivot: consumer → business.** Positioning moves from \"a friend that helps you think, work & feel\" to **\"your coworker, with feelings\"**. Landing Hero + meta description reshaped accordingly.

## What's in the diff

| Area | Files |
|---|---|
| Spec | \`docs/superpowers/specs/2026-04-22-bolly-v1-redesign-design.md\` |
| Plan | \`docs/superpowers/plans/2026-04-22-foundations.md\` |
| TS scaffold | \`server-ts/\` (package.json, tsconfig, vitest, biome, .gitignore, empty src) |
| First module | \`server-ts/src/types.ts\` (10 zod schemas + types) + test |
| Landing copy | \`landing/src/lib/components/Hero.svelte\`, \`landing/src/app.html\` |

## Progress on Plan 1

- ✅ Task 1 — scaffold server-ts (pnpm + TS + vitest + biome)
- ✅ Task 2 — core type definitions (Event, Skill, BudgetDaily, Outreach — 6/6 tests passing)
- ⏸️ Tasks 3–18 — paused; continues in a new session for context

## Reviewer notes

- **Why Messages API, not Managed Agents?** Managed Agents spins up a per-session container for built-in tools (bash, file ops, code). Bolly uses **zero** built-in tools — everything is custom (outreach, drops, memory, cross-instance). Plus ZDR coverage is unclear for Managed Agents; it's confirmed for the Messages API. See \`Alternatives considered → Runtime substrate\` in the spec for the full reasoning.
- **Clean-slate v1.0** — no backward compatibility with v0.x workspaces. We have no users yet, so this is safe. Spec \`Launch strategy\` section explains.
- **zod v3 + \`exactOptionalPropertyTypes\`** is a known friction that may bite tasks 3–8. Hasn't yet.
- **Task 12 reminder** — needs to add \`tinyglobby\` to deps (flagged in spec's plan self-review).

## Test plan

- [x] \`pnpm check\` clean in \`server-ts/\`
- [x] \`pnpm test\` — 6/6 passing
- [ ] Tasks 3–18 to be implemented subagent-driven in next session
- [ ] End-to-end cost validation (\`$2/employee/day\` target) — Plan 6 / Task 18

## Not in this PR (deferred)

- Managed cloud / SaaS hosting (v1 is self-hosted only)
- Messaging app outreach (Slack, Teams, iMessage, Telegram — v1.1)
- Ambient features (screen observation, audio, location — v1.x)
- Persona-first onboarding rebuild — v1.1
- SOC2 / SSO / fine-grained data governance — v1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)